### PR TITLE
Use ose-3.0 but not epel repos

### DIFF
--- a/9.2/Dockerfile.rhel7
+++ b/9.2/Dockerfile.rhel7
@@ -30,11 +30,15 @@ EXPOSE 5432
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
+# rhel-7-server-ose-3.0-rpms is enabled for nss_wrapper until this pkg is
+# in base RHEL
 RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum-config-manager --enable rhel-7-server-ose-3.0-rpms && \
+    yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="rsync tar gettext bind-utils postgresql92 postgresql92-postgresql-contrib nss_wrapper" && \
-    yum install -y --disablerepo="epel" --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/9.4/Dockerfile.rhel7
+++ b/9.4/Dockerfile.rhel7
@@ -31,11 +31,15 @@ EXPOSE 5432
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
+# rhel-7-server-ose-3.0-rpms is enabled for nss_wrapper until this pkg is
+# in base RHEL
 RUN yum install -y yum-utils gettext && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum-config-manager --enable rhel-7-server-ose-3.0-rpms && \
+    yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql94 rh-postgresql94-postgresql-contrib  nss_wrapper" && \
-    yum install -y --disablerepo="epel" --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \


### PR DESCRIPTION
nss_wrapper is available in ose-3.0 repository and we should make sure `docker build` does not fail if epel repository is not defined at all.