### PR TITLE
Add a test for master restart after being killed

### DIFF
--- a/hack/run_test
+++ b/hack/run_test
@@ -269,27 +269,14 @@ function run_master() {
     -d --cidfile ${CIDFILE_DIR}/master-${suffix}.cid $IMAGE_NAME run-postgresql-master >/dev/null
 }
 
-function run_replication_test() {
-  echo "Testing master-slave replication"
-  local cluster_args="-e POSTGRESQL_ADMIN_PASSWORD=pass -e POSTGRESQL_MASTER_USER=$PGUSER -e POSTGRESQL_MASTER_PASSWORD=$PASS"
+function test_slave_visibility() {
+  local cid_suffix="$1"; shift
   local max_attempts=30
-  local cid_suffix="basic"
 
-  # Run the PostgreSQL master
-  run_master $cid_suffix
-  local master_ip
-  master_ip=$(get_container_ip master-$cid_suffix.cid)
-
-  # Run the PostgreSQL slaves
-  local i
-  for i in $(seq ${SLAVE_NUM:-1}); do
-    run_slave $master_ip $cid_suffix-$i
-  done
-
-  # Check if the master knows about the slaves
-  CONTAINER_IP=$master_ip
   local f
   local slave_ip
+  local cidfile
+  local master_ip=$(get_container_ip master-$cid_suffix.cid)
   for f in `find ${CIDFILE_DIR} -type f -name "slave-$cid_suffix-*"`; do
     cidfile=$(basename $f)
     slave_ip=$(get_container_ip $cidfile)
@@ -308,21 +295,29 @@ function run_replication_test() {
       sleep 1
     done
   done
+}
 
+function test_value_replication() {
+  local table_name="$1"; shift
+  local max_attempts=30
+
+  # Setup the replication data
   local value
   value=24
-  # Do some real work to test replication in practice
-  postgresql_cmd -c "CREATE TABLE t1 (a integer); INSERT INTO t1 VALUES ($value);"
+  local table_name="t1"
+  postgresql_cmd -c "CREATE TABLE $table_name (a integer); INSERT INTO $table_name VALUES ($value);"
 
   # Read value from slaves and check whether it is expected
   local f
   local slave_ip
+  local cidfile
+  local master_ip=$(get_container_ip master-$cid_suffix.cid)
   for f in `find ${CIDFILE_DIR} -type f -name "slave-*"`; do
     cidfile=$(basename $f)
     slave_ip=$(get_container_ip $cidfile)
     CONTAINER_IP=$slave_ip
     for i in $(seq $max_attempts); do
-      result="$(postgresql_cmd -At -c "select * from t1")"
+      result="$(postgresql_cmd -At -c "select * from $table_name")"
       if [[ ! -z "${result}" ]]; then
         echo "${slave_ip} successfully got value from MASTER ${master_ip}"
         break
@@ -336,6 +331,36 @@ function run_replication_test() {
       sleep 1
     done
   done
+}
+
+function setup_replication_cluster() {
+  # Run the PostgreSQL master
+  run_master $cid_suffix
+  local master_ip
+  master_ip=$(get_container_ip master-$cid_suffix.cid)
+
+  # Run the PostgreSQL slaves
+  local i
+  for i in $(seq ${SLAVE_NUM:-1}); do
+    run_slave $master_ip $cid_suffix-$i
+  done
+
+  # Check if the master knows about the slaves
+  CONTAINER_IP=$master_ip
+  test_slave_visibility $cid_suffix
+}
+
+function run_replication_test() {
+  echo "Testing master-slave replication"
+  local cluster_args="-e POSTGRESQL_ADMIN_PASSWORD=pass -e POSTGRESQL_MASTER_USER=$PGUSER -e POSTGRESQL_MASTER_PASSWORD=$PASS"
+  local cid_suffix="basic"
+  local table_name="t1"
+
+  # Setup the cluster
+  setup_replication_cluster
+
+  # Do some real work to test replication in practice
+  test_value_replication $table_name
 }
 
 function run_change_password_test() {

--- a/hack/run_test
+++ b/hack/run_test
@@ -32,6 +32,17 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+function cleanup_volume() {
+  local volume_dir="$1"; shift
+  local cid="$1"; shift
+  local volume_args="-v ${volume_dir}:/var/lib/pgsql/data:Z"
+
+  docker stop $cid
+  local rm_cmd='/bin/rm -rf /var/lib/pgsql/data/*'
+  docker run $volume_args --rm $IMAGE_NAME /bin/sh -c "$rm_cmd"
+  rmdir ${volume_dir}
+}
+
 function get_cid() {
   local id="$1" ; shift || return 1
   echo $(cat "$CIDFILE_DIR/$id")
@@ -97,6 +108,13 @@ function create_container() {
   # create container with a cidfile in a directory for cleanup
   docker run $cargs --cidfile $cidfile -d $IMAGE_NAME "$@"
   echo "Created container $(cat $cidfile)"
+}
+
+function create_volume() {
+  local volume_dir
+  volume_dir=`mktemp -d --tmpdir pg-testdata.XXXXX`
+  chmod a+rwx ${volume_dir}
+  echo $volume_dir
 }
 
 function assert_login_access() {
@@ -269,7 +287,8 @@ function run_slave() {
 
 function run_master() {
   local suffix="$1"; shift
-  docker run $cluster_args -p 5432  \
+  master_args=${master_args-}
+  docker run $cluster_args $master_args \
     -d --cidfile ${CIDFILE_DIR}/master-${suffix}.cid $IMAGE_NAME run-postgresql-master >/dev/null
 }
 
@@ -308,8 +327,8 @@ function test_value_replication() {
     slave_ip=$(get_ip_from_cid $slave)
     CONTAINER_IP=$slave_ip
     for i in $(seq $max_attempts); do
-      result="$(postgresql_cmd -At -c "select * from $table_name")"
-      if [[ ! -z "${result}" ]]; then
+      result="$(postgresql_cmd -At -c "select * from $table_name" || :)"
+      if [[ "$result" == "$value" ]]; then
         echo "${slave_ip} successfully got value from MASTER ${master_ip}"
         break
       fi
@@ -331,9 +350,47 @@ function setup_replication_cluster() {
 
   # Run the PostgreSQL slaves
   local i
-  for i in $(seq ${SLAVE_NUM:-1}); do
+  for i in $(seq ${slave_num:-1}); do
     slave_cids="$slave_cids $(run_slave $cid_suffix-$i)"
   done
+
+}
+
+function run_master_restart_test() {
+  echo "Testing failed master restart"
+  local cluster_args="-e POSTGRESQL_ADMIN_PASSWORD=pass -e POSTGRESQL_MASTER_USER=$PGUSER -e POSTGRESQL_MASTER_PASSWORD=$PASS"
+  local cid_suffix="mrestart"
+  local table_name="t1"
+  local master_ip=
+  local slave_cids=
+
+  local volume_dir=$(create_volume)
+  local master_args="-v ${volume_dir}:/var/lib/pgsql/data:Z"
+
+  # Setup the cluster
+  slave_num=2 setup_replication_cluster
+
+  # Check if the master knows about the slaves
+  CONTAINER_IP=$master_ip
+  test_slave_visibility
+
+  echo "Kill the master and create a new one"
+  local cidfile=$CIDFILE_DIR/master-$cid_suffix.cid
+  docker kill $(cat $cidfile)
+  # Don't forget to remove its .cid file
+  rm $cidfile
+
+  run_master $cid_suffix
+  CONTAINER_IP=$(get_container_ip master-$cid_suffix.cid)
+
+  # Check if the new master sees existing slaves
+  test_slave_visibility
+
+  # Check if the replication works
+  table_name="t1" test_value_replication
+
+  # Cleanup the volume
+  cleanup_volume $volume_dir $(cat $cidfile)
 }
 
 function run_replication_test() {
@@ -363,10 +420,7 @@ function run_change_password_test() {
   local password='password'
   local admin_password='adminPassword'
 
-  local volume_dir
-  volume_dir=`mktemp -d --tmpdir pg-testdata.XXXXX`
-  chmod a+rwx ${volume_dir}
-
+  local volume_dir=$(create_volume)
   local volume_options="-v ${volume_dir}:/var/lib/pgsql/data:Z"
 
   DOCKER_ARGS="
@@ -421,9 +475,7 @@ $volume_options
   # into account 0077 umask of PostgreSQL server, we are unable to remove files
   # created by server.  That's why we need to let docker escalate the privileges
   # again.
-  local rm_cmd='/bin/rm -rf /var/lib/pgsql/data/*'
-  docker run $volume_options --rm $IMAGE_NAME /bin/sh -c "$rm_cmd"
-  rmdir ${volume_dir}
+  cleanup_volume $volume_dir $(get_cid ${name})
 
   echo "  Success!"
 }
@@ -445,3 +497,4 @@ DOCKER_ARGS="-u 12345" PGUSER=user3 PASS=pass1 ADMIN_PASS=r00t run_tests admin_a
 DB=postgres DOCKER_ARGS="-u 12345" ADMIN_PASS=rOOt run_tests only_admin_altuid
 run_change_password_test
 DB=postgres PGUSER=master PASS=master run_replication_test
+DB=postgres PGUSER=master PASS=master run_master_restart_test

--- a/hack/run_test
+++ b/hack/run_test
@@ -42,6 +42,11 @@ function get_container_ip() {
   docker inspect --format='{{.NetworkSettings.IPAddress}}' $(get_cid "$id")
 }
 
+function get_ip_from_cid() {
+  local cid="$1"; shift
+  docker inspect --format='{{.NetworkSettings.IPAddress}}' $cid
+}
+
 function postgresql_cmd() {
   docker run --rm -e PGPASSWORD="${PASS}" $IMAGE_NAME psql postgresql://$PGUSER@$CONTAINER_IP:5432/"${DB-db}" "$@"
 }
@@ -257,10 +262,9 @@ function run_tests() {
 }
 
 function run_slave() {
-  local master_ip="$1"; shift
   local suffix="$1"; shift
   docker run $cluster_args -e POSTGRESQL_MASTER_IP=${master_ip} \
-    -d --cidfile ${CIDFILE_DIR}/slave-${suffix}.cid $IMAGE_NAME run-postgresql-slave >/dev/null
+    -d --cidfile ${CIDFILE_DIR}/slave-${suffix}.cid $IMAGE_NAME run-postgresql-slave
 }
 
 function run_master() {
@@ -270,16 +274,10 @@ function run_master() {
 }
 
 function test_slave_visibility() {
-  local cid_suffix="$1"; shift
   local max_attempts=30
 
-  local f
-  local slave_ip
-  local cidfile
-  local master_ip=$(get_container_ip master-$cid_suffix.cid)
-  for f in `find ${CIDFILE_DIR} -type f -name "slave-$cid_suffix-*"`; do
-    cidfile=$(basename $f)
-    slave_ip=$(get_container_ip $cidfile)
+  for slave in $slave_cids; do
+    slave_ip=$(get_ip_from_cid $slave)
     for i in $(seq $max_attempts); do
       result="$(postgresql_cmd -c "select client_addr from pg_stat_replication;" | grep "$slave_ip" || true)"
       if [[ -n "${result}" ]]; then
@@ -288,8 +286,8 @@ function test_slave_visibility() {
       fi
       if [[ "${i}" == "${max_attempts}" ]]; then
         echo "The ${slave_ip} failed to register in MASTER"
-        echo "Dumping logs for $(get_cid $cidfile)"
-        docker logs $(get_cid $cidfile)
+        echo "Dumping logs for $slave"
+        docker logs $slave
         return 1
       fi
       sleep 1
@@ -298,23 +296,16 @@ function test_slave_visibility() {
 }
 
 function test_value_replication() {
-  local table_name="$1"; shift
   local max_attempts=30
 
   # Setup the replication data
   local value
   value=24
-  local table_name="t1"
   postgresql_cmd -c "CREATE TABLE $table_name (a integer); INSERT INTO $table_name VALUES ($value);"
 
   # Read value from slaves and check whether it is expected
-  local f
-  local slave_ip
-  local cidfile
-  local master_ip=$(get_container_ip master-$cid_suffix.cid)
-  for f in `find ${CIDFILE_DIR} -type f -name "slave-*"`; do
-    cidfile=$(basename $f)
-    slave_ip=$(get_container_ip $cidfile)
+  for slave in $slave_cids; do
+    slave_ip=$(get_ip_from_cid $slave)
     CONTAINER_IP=$slave_ip
     for i in $(seq $max_attempts); do
       result="$(postgresql_cmd -At -c "select * from $table_name")"
@@ -324,8 +315,8 @@ function test_value_replication() {
       fi
       if [[ "${i}" == "${max_attempts}" ]]; then
         echo "The ${slave_ip} failed to see value added on MASTER"
-        echo "Dumping logs for $(get_cid $cidfile)"
-        docker logs $(get_cid $cidfile)
+        echo "Dumping logs for $slave"
+        docker logs $slave
         return 1
       fi
       sleep 1
@@ -336,31 +327,31 @@ function test_value_replication() {
 function setup_replication_cluster() {
   # Run the PostgreSQL master
   run_master $cid_suffix
-  local master_ip
   master_ip=$(get_container_ip master-$cid_suffix.cid)
 
   # Run the PostgreSQL slaves
   local i
   for i in $(seq ${SLAVE_NUM:-1}); do
-    run_slave $master_ip $cid_suffix-$i
+    slave_cids="$slave_cids $(run_slave $cid_suffix-$i)"
   done
-
-  # Check if the master knows about the slaves
-  CONTAINER_IP=$master_ip
-  test_slave_visibility $cid_suffix
 }
 
 function run_replication_test() {
   echo "Testing master-slave replication"
   local cluster_args="-e POSTGRESQL_ADMIN_PASSWORD=pass -e POSTGRESQL_MASTER_USER=$PGUSER -e POSTGRESQL_MASTER_PASSWORD=$PASS"
   local cid_suffix="basic"
-  local table_name="t1"
+  local master_ip=
+  local slave_cids=
 
   # Setup the cluster
   setup_replication_cluster
 
+  # Check if the master knows about the slaves
+  CONTAINER_IP=$master_ip
+  test_slave_visibility
+
   # Do some real work to test replication in practice
-  test_value_replication $table_name
+  table_name="t1" test_value_replication
 }
 
 function run_change_password_test() {


### PR DESCRIPTION
This PR adds a simple test to check if a master can be properly restarted after being killed in a replication scenario.
First commit makes some necessary changes to existing test code while the second commit adds the actual test.