### PR TITLE
Fix permissions for using persistent storage

### DIFF
--- a/9.2/root/usr/libexec/fix-permissions
+++ b/9.2/root/usr/libexec/fix-permissions
@@ -4,4 +4,4 @@
 find "$1" -exec chown postgres {} \;
 find "$1" -exec chgrp 0 {} \;
 find "$1" -exec chmod g+rw {} \;
-find "$1" -type d -exec chmod g+x {} +
+find "$1" -type d -exec chmod +xw {} +

--- a/9.4/root/usr/libexec/fix-permissions
+++ b/9.4/root/usr/libexec/fix-permissions
@@ -4,4 +4,4 @@
 find "$1" -exec chown postgres {} \;
 find "$1" -exec chgrp 0 {} \;
 find "$1" -exec chmod g+rw {} \;
-find "$1" -type d -exec chmod g+x {} +
+find "$1" -type d -exec chmod +xw {} +

--- a/9.5/root/usr/libexec/fix-permissions
+++ b/9.5/root/usr/libexec/fix-permissions
@@ -4,4 +4,4 @@
 find "$1" -exec chown postgres {} \;
 find "$1" -exec chgrp 0 {} \;
 find "$1" -exec chmod g+rw {} \;
-find "$1" -type d -exec chmod g+x {} +
+find "$1" -type d -exec chmod +xw {} +


### PR DESCRIPTION
Postgresql pod is CrashLoopBackOff if using persistent storage.

Please, see postgresql container logs.

    Success. You can now start the database server using:

        postgres -D /var/lib/pgsql/data/userdata
    or
        pg_ctl -D /var/lib/pgsql/data/userdata -l logfile start


    WARNING: enabling "trust" authentication for local connections
    You can change this by editing pg_hba.conf or using the option -A, or
    --auth-local and --auth-host, the next time you run initdb.
    waiting for server to start....FATAL:  data directory "/var/lib/pgsql/data/userdata" has wrong ownership
    HINT:  The server must be started by the user that owns the data directory.
    .... stopped waiting
    pg_ctl: could not start server
    Examine the log output.
