### PR TITLE
Make test cases independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ Users can choose between testing PostgreSQL based on a RHEL or CentOS image.
     $ cd postgresql
     $ make test VERSION=9.2
     ```
++By using the `TEST_CASE` parameter you can choose a test case subset to be run against the image, eg:
+
+    $ cd postgresql
+    $ make test VERSION=9.2 TEST_CASE="run_general_tests run_replication_test"
+
 
 **Notice: By omitting the `VERSION` parameter, the build/test action will be performed
 on all provided versions of PostgreSQL.**

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -92,8 +92,7 @@ for dir in ${dirs}; do
   fi
 
   if [[ -v TEST_MODE ]]; then
-    VERSION=$dir IMAGE_NAME=${IMAGE_NAME} test/run
-
+    make -C ../ ${TEST_CASE:-runtests} VERSION=$dir IMAGE_NAME=${IMAGE_NAME}
     if [[ $? -eq 0 ]] && [[ "${TAG_ON_SUCCESS}" == "true" ]]; then
       echo "-> Re-tagging ${IMAGE_NAME} image to ${IMAGE_NAME%"-candidate"}"
       docker tag -f $IMAGE_NAME ${IMAGE_NAME%"-candidate"}

--- a/hack/common.mk
+++ b/hack/common.mk
@@ -8,7 +8,10 @@ else
 	OS := centos7
 endif
 
+tests = $(shell hack/run_test --list 2>/dev/null)
+
 script_env = \
+	TEST_CASE="$(TEST_CASE)"                        \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \
 	UPDATE_BASE=$(UPDATE_BASE)                      \
 	VERSIONS="$(VERSIONS)"                          \
@@ -24,3 +27,10 @@ build:
 .PHONY: test
 test:
 	$(script_env) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true $(build)
+
+.PHONY: runtests
+runtests: $(tests)
+
+$(tests):
+	@echo Running test: $@;
+	VERSION=$(VERSION) IMAGE_NAME=$(IMAGE_NAME) hack/run_test $@;

--- a/hack/run_test
+++ b/hack/run_test
@@ -9,9 +9,19 @@
 set -exo nounset
 shopt -s nullglob
 
+TEST_LIST="\
+run_container_creation_tests
+run_general_tests
+run_change_password_test
+run_replication_test
+run_master_restart_test"
+
+test $# -eq 1 -a ${1-} == --list && echo "$TEST_LIST" && exit 0
 test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
 test -n "${VERSION-}" || false 'make sure $VERSION is defined'
+
 CIDFILE_DIR=$(mktemp --suffix=postgresql_test_cidfiles -d)
+
 
 function cleanup() {
   for cidfile in $CIDFILE_DIR/* ; do
@@ -357,6 +367,10 @@ function setup_replication_cluster() {
 }
 
 function run_master_restart_test() {
+  local DB=postgres
+  local PGUSER=master
+  local PASS=master
+
   echo "Testing failed master restart"
   local cluster_args="-e POSTGRESQL_ADMIN_PASSWORD=pass -e POSTGRESQL_MASTER_USER=$PGUSER -e POSTGRESQL_MASTER_PASSWORD=$PASS"
   local cid_suffix="mrestart"
@@ -394,6 +408,10 @@ function run_master_restart_test() {
 }
 
 function run_replication_test() {
+  local DB=postgres
+  local PGUSER=master
+  local PASS=master
+
   echo "Testing master-slave replication"
   local cluster_args="-e POSTGRESQL_ADMIN_PASSWORD=pass -e POSTGRESQL_MASTER_USER=$PGUSER -e POSTGRESQL_MASTER_PASSWORD=$PASS"
   local cid_suffix="basic"
@@ -480,21 +498,27 @@ $volume_options
   echo "  Success!"
 }
 
+function run_general_tests() {
+  PGUSER=user PASS=pass POSTGRESQL_MAX_CONNECTIONS=42 POSTGRESQL_MAX_PREPARED_TRANSACTIONS=42 POSTGRESQL_SHARED_BUFFERS=64MB run_tests no_admin
+  PGUSER=user1 PASS=pass1 ADMIN_PASS=r00t run_tests admin
+  DB=postgres ADMIN_PASS=r00t run_tests only_admin
+  # Test with arbitrary uid for the container
+  DOCKER_ARGS="-u 12345" PGUSER=user2 PASS=pass run_tests no_admin_altuid
+  DOCKER_ARGS="-u 12345" PGUSER=user3 PASS=pass1 ADMIN_PASS=r00t run_tests admin_altuid
+  DB=postgres DOCKER_ARGS="-u 12345" ADMIN_PASS=rOOt run_tests only_admin_altuid
+}
+
+function run_all_tests() {
+  for test_case in $TEST_LIST; do
+    : "Running test $test_case"
+    $test_case
+  done;
+}
+
 # configuration defaults
 POSTGRESQL_MAX_CONNECTIONS=100
 POSTGRESQL_MAX_PREPARED_TRANSACTIONS=0
 POSTGRESQL_SHARED_BUFFERS=32MB
 
-# Tests.
-
-run_container_creation_tests
-PGUSER=user PASS=pass POSTGRESQL_MAX_CONNECTIONS=42 POSTGRESQL_MAX_PREPARED_TRANSACTIONS=42 POSTGRESQL_SHARED_BUFFERS=64MB run_tests no_admin
-PGUSER=user1 PASS=pass1 ADMIN_PASS=r00t run_tests admin
-DB=postgres ADMIN_PASS=r00t run_tests only_admin
-# Test with arbitrary uid for the container
-DOCKER_ARGS="-u 12345" PGUSER=user2 PASS=pass run_tests no_admin_altuid
-DOCKER_ARGS="-u 12345" PGUSER=user3 PASS=pass1 ADMIN_PASS=r00t run_tests admin_altuid
-DB=postgres DOCKER_ARGS="-u 12345" ADMIN_PASS=rOOt run_tests only_admin_altuid
-run_change_password_test
-DB=postgres PGUSER=master PASS=master run_replication_test
-DB=postgres PGUSER=master PASS=master run_master_restart_test
+# Run the chosen tests
+TEST_LIST=${@:-$TEST_LIST} run_all_tests


### PR DESCRIPTION
First try on independent tests. Related to #140 

This PR moves each of the existing test cases into their own file inside `hack/tests` directory and provides a Makefile to run them.

Open questions:
1. What do we do with leftover `$VERSION/test/run` soft links?
2. Do we leave the new test files in `hack/tests` directory or somewhere else?
3. Divide `general` tests? How?