### PR TITLE
Remove VERSION argument from common.mk

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -78,7 +78,7 @@ for dir in ${dirs}; do
 
   IMAGE_NAME="${NAMESPACE}${BASE_IMAGE_NAME}-${dir//./}-${OS}"
 
-  if [[ -v TEST_MODE ]]; then
+  if [[ "${TEST_MODE}" == "true" ]]; then
     IMAGE_NAME+="-candidate"
   fi
 
@@ -91,7 +91,7 @@ for dir in ${dirs}; do
     docker_build_with_version Dockerfile
   fi
 
-  if [[ -v TEST_MODE ]]; then
+  if [[ "${TEST_MODE}" == "true" ]]; then
     make -C ../ ${TEST_CASE:-runtests} VERSION=$dir IMAGE_NAME=${IMAGE_NAME}
     if [[ $? -eq 0 ]] && [[ "${TAG_ON_SUCCESS}" == "true" ]]; then
       echo "-> Re-tagging ${IMAGE_NAME} image to ${IMAGE_NAME%"-candidate"}"

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -78,7 +78,7 @@ for dir in ${dirs}; do
 
   IMAGE_NAME="${NAMESPACE}${BASE_IMAGE_NAME}-${dir//./}-${OS}"
 
-  if [[ "${TEST_MODE}" == "true" ]]; then
+  if [[ -v TEST_MODE ]]; then
     IMAGE_NAME+="-candidate"
   fi
 
@@ -91,7 +91,7 @@ for dir in ${dirs}; do
     docker_build_with_version Dockerfile
   fi
 
-  if [[ "${TEST_MODE}" == "true" ]]; then
+  if [[ -v TEST_MODE ]]; then
     make -C ../ ${TEST_CASE:-runtests} VERSION=$dir IMAGE_NAME=${IMAGE_NAME}
     if [[ $? -eq 0 ]] && [[ "${TAG_ON_SUCCESS}" == "true" ]]; then
       echo "-> Re-tagging ${IMAGE_NAME} image to ${IMAGE_NAME%"-candidate"}"

--- a/hack/common.mk
+++ b/hack/common.mk
@@ -11,22 +11,24 @@ endif
 tests = $(shell hack/run_test --list 2>/dev/null)
 
 script_env = \
+	TAG_ON_SUCCESS=$(TAG_ON_SUCCESS)                \
 	TEST_CASE="$(TEST_CASE)"                        \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \
 	UPDATE_BASE=$(UPDATE_BASE)                      \
-	VERSIONS="$(VERSIONS)"                          \
 	OS=$(OS)                                        \
-	VERSION="$(VERSION)"                            \
 	BASE_IMAGE_NAME=$(BASE_IMAGE_NAME)              \
 	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"
 
 .PHONY: build
-build:
-	$(script_env) $(build)
+build: $(VERSIONS)
+
+.PHONY: $(VERSIONS)
+$(VERSIONS):
+	VERSION=$@ TEST_MODE=$(TEST_MODE) $(script_env) $(build)
 
 .PHONY: test
-test:
-	$(script_env) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true $(build)
+test: TEST_MODE=true
+test: build
 
 .PHONY: runtests
 runtests: $(tests)

--- a/hack/common.mk
+++ b/hack/common.mk
@@ -24,10 +24,10 @@ build: $(VERSIONS)
 
 .PHONY: $(VERSIONS)
 $(VERSIONS):
-	VERSION=$@ TEST_MODE=$(TEST_MODE) $(script_env) $(build)
+	VERSION=$@ $(script_env) $(build)
 
 .PHONY: test
-test: TEST_MODE=true
+test: script_env += TEST_MODE=true
 test: build
 
 .PHONY: runtests


### PR DESCRIPTION
For the most part removes the use of VERSION argument from common.mk (only used in `make runtests` via build.sh now). Does not modify version handling in build.sh in order to still be able to build all images without calling make.
This should allow us to run multiple docker builds in parallel in the future via make.

Briefly discussed in #151 