### PR TITLE
Include states in run-postgresql

### DIFF
--- a/9.4/root/usr/bin/run-postgresql
+++ b/9.4/root/usr/bin/run-postgresql
@@ -13,6 +13,7 @@ generate_passwd_file
 generate_postgresql_config
 
 if [ ! -f "$PGDATA/status/1.initialize_database_done" ]; then
+  find $PGDATA -mindepth 1 -delete
   initialize_database
   mkdir -p $PGDATA/status/
   touch $PGDATA/status/1.initialize_database_done

--- a/9.4/root/usr/bin/run-postgresql
+++ b/9.4/root/usr/bin/run-postgresql
@@ -12,16 +12,21 @@ check_env_vars
 generate_passwd_file
 generate_postgresql_config
 
-if [ ! -f "$PGDATA/postgresql.conf" ]; then
+if [ ! -f "$PGDATA/status/1.initialize_database_done" ]; then
   initialize_database
-  NEED_TO_CREATE_USERS=yes
+  mkdir -p $PGDATA/status/
+  touch $PGDATA/status/1.initialize_database_done
 fi
 
 pg_ctl -w start -o "-h ''"
-if [ "${NEED_TO_CREATE_USERS:-}" == "yes" ]; then
+if [ ! -f "$PGDATA/status/2.create_users_done" ]; then
   create_users
+  touch $PGDATA/status/2.create_users_done
 fi
-set_passwords
+if [ ! -f "$PGDATA/status/3.set_passwords_done" ]; then
+  set_passwords
+  touch $PGDATA/status/3.set_passwords_done
+fi
 pg_ctl stop
 
 unset_env_vars


### PR DESCRIPTION
We've noticed, with persistent storage, that if the script is interrupted between lines 16 and 20 users never get created even on following container restarts because "$PGDATA/postgresql.conf" gets created before create_users is run.
I have added states for each critical step in the startup in the folder "$PGDATA/status".
As a side question, is there a particular reason to call set_passwords every time? (this is why I have also added the if status for it)