### PR TITLE
Speedup 'docker build' from caches

### DIFF
--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.k8s.description="PostgreSQL is an advanced Object-Relational database m
 
 EXPOSE 5432
 
-ADD root /
+ADD root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
@@ -42,6 +42,8 @@ RUN yum install -y centos-release-scl && \
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
     ENABLED_COLLECTIONS=rh-postgresql94
+
+ADD root /
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/9.4/Dockerfile.rhel7
+++ b/9.4/Dockerfile.rhel7
@@ -28,7 +28,7 @@ LABEL name="rhscl/postgresql-94-rhel7" \
 
 EXPOSE 5432
 
-ADD root /
+ADD root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
@@ -52,6 +52,8 @@ RUN yum install -y yum-utils gettext && \
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
     ENABLED_COLLECTIONS=rh-postgresql94
+
+ADD root /
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.k8s.description="PostgreSQL is an advanced Object-Relational database m
 
 EXPOSE 5432
 
-ADD root /
+ADD root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
@@ -42,6 +42,8 @@ RUN yum install -y centos-release-scl-rh && \
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
     ENABLED_COLLECTIONS=rh-postgresql95
+
+ADD root /
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/9.5/Dockerfile.rhel7
+++ b/9.5/Dockerfile.rhel7
@@ -28,7 +28,7 @@ LABEL name="rhscl/postgresql-95-rhel7" \
 
 EXPOSE 5432
 
-ADD root /
+ADD root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
@@ -52,6 +52,8 @@ RUN yum install -y yum-utils gettext && \
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
     ENABLED_COLLECTIONS=rh-postgresql95
+
+ADD root /
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable


### PR DESCRIPTION
Installing of RPM takes fair amount of time so we need to have it
done before 'ADD root /' statement;  so if something is changed in
'root' directory, 'docker build' doesn't have to re-download and
re-install all the packages.

There's, however, still the 'aufs' docker issue we touched in
issue #116 (docker/docker#24660) so we need to have
`fix-permissions` installed before package installation is done.