### PR TITLE
Remove warning when running the test suite without any arguments

### DIFF
--- a/hack/run_test
+++ b/hack/run_test
@@ -17,7 +17,7 @@ run_replication_test
 run_master_restart_test
 run_doc_test"
 
-test $# -eq 1 -a ${1-} == --list && echo "$TEST_LIST" && exit 0
+test $# -eq 1 -a "${1-}" == --list && echo "$TEST_LIST" && exit 0
 test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
 test -n "${VERSION-}" || false 'make sure $VERSION is defined'
 


### PR DESCRIPTION
Fixes the pesky warning when the test suite is run without any arguments:
`+ test 0 -eq 1 -a == --list`
`hack/run_test: line 20: test: too many arguments`