### PR TITLE
Dockerfiles update

### DIFF
--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -16,10 +16,23 @@ ENV POSTGRESQL_VERSION=9.4 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-LABEL io.k8s.description="PostgreSQL is an advanced Object-Relational database management system" \
+ENV SUMMARY="The programs needed to create and run a PostgreSQL server $POSTGRESQL_VERSION" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management \
+system (DBMS). This image contains the programs needed to create \
+and run a PostgreSQL server, the client \
+programs that you'll need to access a PostgreSQL DBMS server, as \
+well as HTML documentation for the whole system."
+
+LABEL summary=$SUMMARY \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="PostgreSQL 9.4" \
       io.openshift.expose-services="5432:postgresql" \
-      io.openshift.tags="database,postgresql,postgresql94,rh-postgresql94"
+      io.openshift.tags="database,postgresql,postgresql94,rh-postgresql94" \
+      name="centos/postgresql-94-centos7" \
+      com.redhat.component="rh-postgresql94-docker" \
+      version="9.4" \
+      release="1"
 
 EXPOSE 5432
 

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -16,12 +16,10 @@ ENV POSTGRESQL_VERSION=9.4 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-ENV SUMMARY="The programs needed to create and run a PostgreSQL server $POSTGRESQL_VERSION" \
-    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management \
-system (DBMS). This image contains the programs needed to create \
-and run a PostgreSQL server, the client \
-programs that you'll need to access a PostgreSQL DBMS server, as \
-well as HTML documentation for the whole system."
+ENV SUMMARY="Advanced Object-Relational database management system" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
+The image contains the client and server programs that you'll need to \
+create, run, maintain and access a PostgreSQL DBMS server."
 
 LABEL summary=$SUMMARY \
       description="$DESCRIPTION" \

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -16,7 +16,7 @@ ENV POSTGRESQL_VERSION=9.4 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-ENV SUMMARY="Advanced Object-Relational database management system" \
+ENV SUMMARY="PostgreSQL is an advanced Object-Relational database management system" \
     DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
 The image contains the client and server programs that you'll need to \
 create, run, maintain and access a PostgreSQL DBMS server."

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -10,8 +10,6 @@ FROM centos:centos7
 #  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
 #                           PostgreSQL administrative account
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 ENV POSTGRESQL_VERSION=9.4 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
@@ -30,7 +28,8 @@ LABEL summary=$SUMMARY \
       name="centos/postgresql-94-centos7" \
       com.redhat.component="rh-postgresql94-docker" \
       version="9.4" \
-      release="1"
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 5432
 

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.k8s.description="PostgreSQL is an advanced Object-Relational database m
 
 EXPOSE 5432
 
-ADD root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
+COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
@@ -43,7 +43,7 @@ RUN yum install -y centos-release-scl && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
     ENABLED_COLLECTIONS=rh-postgresql94
 
-ADD root /
+COPY root /
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/9.4/Dockerfile.rhel7
+++ b/9.4/Dockerfile.rhel7
@@ -14,17 +14,23 @@ ENV POSTGRESQL_VERSION=9.4 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-LABEL io.k8s.description="PostgreSQL is an advanced Object-Relational database management system" \
+ENV SUMMARY="The programs needed to create and run a PostgreSQL server $POSTGRESQL_VERSION" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management \
+system (DBMS). This image contains the programs needed to create \
+and run a PostgreSQL server, the client \
+programs that you'll need to access a PostgreSQL DBMS server, as \
+well as HTML documentation for the whole system."
+
+LABEL summary=$SUMMARY \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="PostgreSQL 9.4" \
       io.openshift.expose-services="5432:postgresql" \
-      io.openshift.tags="database,postgresql,postgresql94,rh-postgresql94"
-
-# Labels consumed by Red Hat build service
-LABEL name="rhscl/postgresql-94-rhel7" \
+      io.openshift.tags="database,postgresql,postgresql94,rh-postgresql94" \
+      name="rhscl/postgresql-94-rhel7" \
       com.redhat.component="rh-postgresql94-docker" \
       version="9.4" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 EXPOSE 5432
 

--- a/9.4/Dockerfile.rhel7
+++ b/9.4/Dockerfile.rhel7
@@ -14,7 +14,7 @@ ENV POSTGRESQL_VERSION=9.4 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-ENV SUMMARY="Advanced Object-Relational database management system" \
+ENV SUMMARY="PostgreSQL is an advanced Object-Relational database management system" \
     DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
 The image contains the client and server programs that you'll need to \
 create, run, maintain and access a PostgreSQL DBMS server."

--- a/9.4/Dockerfile.rhel7
+++ b/9.4/Dockerfile.rhel7
@@ -28,7 +28,7 @@ LABEL name="rhscl/postgresql-94-rhel7" \
 
 EXPOSE 5432
 
-ADD root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
+COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
@@ -53,7 +53,7 @@ RUN yum install -y yum-utils gettext && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
     ENABLED_COLLECTIONS=rh-postgresql94
 
-ADD root /
+COPY root /
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/9.4/Dockerfile.rhel7
+++ b/9.4/Dockerfile.rhel7
@@ -14,12 +14,10 @@ ENV POSTGRESQL_VERSION=9.4 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-ENV SUMMARY="The programs needed to create and run a PostgreSQL server $POSTGRESQL_VERSION" \
-    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management \
-system (DBMS). This image contains the programs needed to create \
-and run a PostgreSQL server, the client \
-programs that you'll need to access a PostgreSQL DBMS server, as \
-well as HTML documentation for the whole system."
+ENV SUMMARY="Advanced Object-Relational database management system" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
+The image contains the client and server programs that you'll need to \
+create, run, maintain and access a PostgreSQL DBMS server."
 
 LABEL summary=$SUMMARY \
       description="$DESCRIPTION" \

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -16,7 +16,7 @@ ENV POSTGRESQL_VERSION=9.5 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-ENV SUMMARY="Advanced Object-Relational database management system" \
+ENV SUMMARY="PostgreSQL is an advanced Object-Relational database management system" \
     DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
 The image contains the client and server programs that you'll need to \
 create, run, maintain and access a PostgreSQL DBMS server."

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -10,8 +10,6 @@ FROM centos:centos7
 #  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
 #                           PostgreSQL administrative account
 
-LABEL MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 ENV POSTGRESQL_VERSION=9.5 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
@@ -30,7 +28,8 @@ LABEL summary=$SUMMARY \
       name="centos/postgresql-94-centos7" \
       com.redhat.component="rh-postgresql94-docker" \
       version="9.4" \
-      release="1"
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 5432
 

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -10,16 +10,29 @@ FROM centos:centos7
 #  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
 #                           PostgreSQL administrative account
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
+LABEL MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
 
 ENV POSTGRESQL_VERSION=9.5 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-LABEL io.k8s.description="PostgreSQL is an advanced Object-Relational database management system" \
-      io.k8s.display-name="PostgreSQL 9.5" \
+ENV SUMMARY="The programs needed to create and run a PostgreSQL server $POSTGRESQL_VERSION" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management \
+system (DBMS). This image contains the programs needed to create \
+and run a PostgreSQL server, the client \
+programs that you'll need to access a PostgreSQL DBMS server, as \
+well as HTML documentation for the whole system." 
+
+LABEL summary=$SUMMARY \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="PostgreSQL 9.4" \
       io.openshift.expose-services="5432:postgresql" \
-      io.openshift.tags="database,postgresql,postgresql95,rh-postgresql95"
+      io.openshift.tags="database,postgresql,postgresql94,rh-postgresql94" \
+      name="centos/postgresql-94-centos7" \
+      com.redhat.component="rh-postgresql94-docker" \
+      version="9.4" \
+      release="1"
 
 EXPOSE 5432
 

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -22,12 +22,12 @@ create, run, maintain and access a PostgreSQL DBMS server."
 LABEL summary=$SUMMARY \
       description="$DESCRIPTION" \
       io.k8s.description="$SUMMARY" \
-      io.k8s.display-name="PostgreSQL 9.4" \
+      io.k8s.display-name="PostgreSQL 9.5" \
       io.openshift.expose-services="5432:postgresql" \
-      io.openshift.tags="database,postgresql,postgresql94,rh-postgresql94" \
-      name="centos/postgresql-94-centos7" \
-      com.redhat.component="rh-postgresql94-docker" \
-      version="9.4" \
+      io.openshift.tags="database,postgresql,postgresql95,rh-postgresql95" \
+      name="centos/postgresql-95-centos7" \
+      com.redhat.component="rh-postgresql95-docker" \
+      version="9.5" \
       release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.k8s.description="PostgreSQL is an advanced Object-Relational database m
 
 EXPOSE 5432
 
-ADD root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
+COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
@@ -43,7 +43,7 @@ RUN yum install -y centos-release-scl-rh && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
     ENABLED_COLLECTIONS=rh-postgresql95
 
-ADD root /
+COPY root /
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -16,12 +16,10 @@ ENV POSTGRESQL_VERSION=9.5 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-ENV SUMMARY="The programs needed to create and run a PostgreSQL server $POSTGRESQL_VERSION" \
-    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management \
-system (DBMS). This image contains the programs needed to create \
-and run a PostgreSQL server, the client \
-programs that you'll need to access a PostgreSQL DBMS server, as \
-well as HTML documentation for the whole system." 
+ENV SUMMARY="Advanced Object-Relational database management system" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
+The image contains the client and server programs that you'll need to \
+create, run, maintain and access a PostgreSQL DBMS server."
 
 LABEL summary=$SUMMARY \
       description="$DESCRIPTION" \

--- a/9.5/Dockerfile.rhel7
+++ b/9.5/Dockerfile.rhel7
@@ -14,17 +14,23 @@ ENV POSTGRESQL_VERSION=9.5 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-LABEL io.k8s.description="PostgreSQL is an advanced Object-Relational database management system" \
-      io.k8s.display-name="PostgreSQL 9.5" \
-      io.openshift.expose-services="5432:postgresql" \
-      io.openshift.tags="database,postgresql,postgresql95,rh-postgresql95"
+ENV SUMMARY="The programs needed to create and run a PostgreSQL server $POSTGRESQL_VERSION" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management \
+system (DBMS). This image contains the programs needed to create \
+and run a PostgreSQL server, the client \
+programs that you'll need to access a PostgreSQL DBMS server, as \
+well as HTML documentation for the whole system." 
 
-# Labels consumed by Red Hat build service
-LABEL name="rhscl/postgresql-95-rhel7" \
+LABEL summary=$SUMMARY \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="PostgreSQL 9.4" \
+      io.openshift.expose-services="5432:postgresql" \
+      io.openshift.tags="database,postgresql,postgresql94,rh-postgresql94" \
+      name="rhscl/postgresql-95-rhel7" \
       com.redhat.component="rh-postgresql95-docker" \
       version="9.5" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 EXPOSE 5432
 

--- a/9.5/Dockerfile.rhel7
+++ b/9.5/Dockerfile.rhel7
@@ -14,12 +14,10 @@ ENV POSTGRESQL_VERSION=9.5 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-ENV SUMMARY="The programs needed to create and run a PostgreSQL server $POSTGRESQL_VERSION" \
-    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management \
-system (DBMS). This image contains the programs needed to create \
-and run a PostgreSQL server, the client \
-programs that you'll need to access a PostgreSQL DBMS server, as \
-well as HTML documentation for the whole system." 
+ENV SUMMARY="Advanced Object-Relational database management system" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
+The image contains the client and server programs that you'll need to \
+create, run, maintain and access a PostgreSQL DBMS server."
 
 LABEL summary=$SUMMARY \
       description="$DESCRIPTION" \

--- a/9.5/Dockerfile.rhel7
+++ b/9.5/Dockerfile.rhel7
@@ -28,7 +28,7 @@ LABEL name="rhscl/postgresql-95-rhel7" \
 
 EXPOSE 5432
 
-ADD root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
+COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
@@ -53,7 +53,7 @@ RUN yum install -y yum-utils gettext && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
     ENABLED_COLLECTIONS=rh-postgresql95
 
-ADD root /
+COPY root /
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/9.5/Dockerfile.rhel7
+++ b/9.5/Dockerfile.rhel7
@@ -14,7 +14,7 @@ ENV POSTGRESQL_VERSION=9.5 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
-ENV SUMMARY="Advanced Object-Relational database management system" \
+ENV SUMMARY="PostgreSQL is an advanced Object-Relational database management system" \
     DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
 The image contains the client and server programs that you'll need to \
 create, run, maintain and access a PostgreSQL DBMS server."

--- a/9.5/Dockerfile.rhel7
+++ b/9.5/Dockerfile.rhel7
@@ -22,9 +22,9 @@ create, run, maintain and access a PostgreSQL DBMS server."
 LABEL summary=$SUMMARY \
       description="$DESCRIPTION" \
       io.k8s.description="$SUMMARY" \
-      io.k8s.display-name="PostgreSQL 9.4" \
+      io.k8s.display-name="PostgreSQL 9.5" \
       io.openshift.expose-services="5432:postgresql" \
-      io.openshift.tags="database,postgresql,postgresql94,rh-postgresql94" \
+      io.openshift.tags="database,postgresql,postgresql95,rh-postgresql95" \
       name="rhscl/postgresql-95-rhel7" \
       com.redhat.component="rh-postgresql95-docker" \
       version="9.5" \


### PR DESCRIPTION
Use COPY instruction instead of ADD
(COPY is preffered for simple usage - see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy)

Provide same labels for all base image variants (CentOS, RHEL, Fedora)
 - follow recomended labels from Project Atomic Container best practices
 - add summary and description labels (Fedora requirements) - use ENV for simple using of same value in more descriptive labels
 - remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)


@pkubatrh @praiskup What should be values of `SUMMARY` and `DESCRIPTION`? (my suggestion is mix of descriptions from rpms, probably missing something important)

@hhorak @praiskup @pkubatrh Please take a look and merge.