### PR TITLE
rhel7: Build 9.6 with beta packages

### DIFF
--- a/latest/Dockerfile.rhel7
+++ b/latest/Dockerfile.rhel7
@@ -28,8 +28,7 @@ LABEL summary=$SUMMARY \
       io.openshift.tags="database,postgresql,postgresql96,rh-postgresql96" \
       name="rhscl/postgresql-96-rhel7" \
       com.redhat.component="rh-postgresql96-docker" \
-      version="9.6" \
-      release="1"
+      version="1"
 
 EXPOSE 5432
 
@@ -47,6 +46,7 @@ RUN yum repolist > /dev/null && \
     yum install -y yum-utils gettext && \
     yum-config-manager --disable \* &> /dev/null && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum-config-manager --enable rhel-server-rhscl-7-beta-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql96 rh-postgresql96-postgresql-contrib nss_wrapper rh-postgresql95-postgresql-server" && \

--- a/test/run_test
+++ b/test/run_test
@@ -25,6 +25,7 @@ run_doc_test
 test $# -eq 1 -a "${1-}" == --list && echo "$TEST_LIST" && exit 0
 test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
 test -n "${VERSION-}" || false 'make sure $VERSION is defined'
+test -n "${OS-}" || false 'make sure $OS is defined'
 
 CIDFILE_DIR=$(mktemp --suffix=postgresql_test_cidfiles -d)
 
@@ -525,7 +526,8 @@ run_migration_test ()
     local upgrade_path="9.2 9.4 9.5 9.6"
 
     for from_version in $upgrade_path; do
-        test $(version2number $from_version) -le $(version2number "$VERSION") \
+        # Do not test migration from $VERSION:remote to $VERSION:local
+        test $(version2number $from_version) -lt $(version2number "$VERSION") \
             || break
         test/run_migration_test $from_version:remote $VERSION:local
     done


### PR DESCRIPTION
set version label to 1, remove release label completely

@hhorak is the above safe to do in CentOS Dockerfiles as well? So that we can have as similar Dockerfiles as possible.