### PR TITLE
Use distgen for generating Dockerfiles

### DIFF
--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -39,8 +39,8 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql94 rh-postgresql94-postgresql-contrib nss_wrapper postgresql92-postgresql-server rh-postgresql94-postgresql-upgrade" && \
+RUN yum install -y centos-release-scl-rh && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper rh-postgresql94 rh-postgresql94-postgresql-contrib postgresql92-postgresql-server rh-postgresql94-postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/9.4/Dockerfile.rhel7
+++ b/9.4/Dockerfile.rhel7
@@ -45,7 +45,7 @@ RUN yum install -y yum-utils gettext && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql94 rh-postgresql94-postgresql-contrib nss_wrapper postgresql92-postgresql-server rh-postgresql94-postgresql-upgrade" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper rh-postgresql94 rh-postgresql94-postgresql-contrib postgresql92-postgresql-server rh-postgresql94-postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -40,7 +40,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql95 rh-postgresql95-postgresql-contrib nss_wrapper rh-postgresql94-postgresql-server" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper rh-postgresql95 rh-postgresql95-postgresql-contrib rh-postgresql94-postgresql-server" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/9.5/Dockerfile.rhel7
+++ b/9.5/Dockerfile.rhel7
@@ -45,7 +45,7 @@ RUN yum install -y yum-utils gettext && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql95 rh-postgresql95-postgresql-contrib nss_wrapper rh-postgresql94-postgresql-server" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper rh-postgresql95 rh-postgresql95-postgresql-contrib rh-postgresql94-postgresql-server" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,0 +1,83 @@
+FROM {{ config.docker.from }}
+
+# PostgreSQL image for OpenShift.
+# Volumes:
+#  * /var/lib/psql/data   - Database cluster for PostgreSQL
+# Environment:
+#  * $POSTGRESQL_USER     - Database user name
+#  * $POSTGRESQL_PASSWORD - User's password
+#  * $POSTGRESQL_DATABASE - Name of the database to create
+#  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
+#                           PostgreSQL administrative account
+
+ENV POSTGRESQL_VERSION={{ spec.version }} \
+    POSTGRESQL_PREV_VERSION={{ spec.prev_version }} \
+    HOME=/var/lib/pgsql \
+    PGUSER=postgres
+
+ENV SUMMARY="PostgreSQL is an advanced Object-Relational database management system" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
+The image contains the client and server programs that you'll need to \
+create, run, maintain and access a PostgreSQL DBMS server."
+
+LABEL summary=$SUMMARY \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="PostgreSQL {{ spec.version }}" \
+      io.openshift.expose-services="5432:postgresql" \
+      io.openshift.tags="{{ spec.openshift_tags }}" \
+      name="{{ spec.org }}/postgresql-{{ spec.short }}-{{ spec.prod }}" \
+      com.redhat.component="{{ spec.redhat_component }}" \
+{%- if spec.version in spec.rhscl3_introduced %}
+      version="1"
+{%- else %}
+      version="{{ spec.version }}" \
+      release="1"
+{%- endif %}
+{%- if spec.maintainer %} \
+      maintainer="{{ spec.maintainer }}"
+{%- endif %}
+
+EXPOSE 5432
+
+COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
+
+# This image must forever use UID 26 for postgres user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+{%- if spec.repo_enable_reason %}
+{{ spec.repo_enable_reason }}
+{%- endif %}
+RUN {{ spec.environment_setup }}
+{%- if not spec.stable %}
+{{ spec.staging_repo_setup }}
+{%- endif %}
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper {{ spec.pkgs }}" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    localedef -f UTF-8 -i en_US en_US.UTF-8 && \
+    test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
+    mkdir -p /var/lib/pgsql/data && \
+    /usr/libexec/fix-permissions /var/lib/pgsql && \
+    /usr/libexec/fix-permissions /var/run/postgresql
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
+    ENABLED_COLLECTIONS={{ spec.enabled_collection }}
+
+COPY root /
+
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
+
+VOLUME ["/var/lib/pgsql/data"]
+
+USER 26
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-postgresql"]

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,12 @@ include common/common.mk
 # Additional upgrade tests.  Not hooked into CI ATM.
 upgrade-tests: $(VERSIONS)
 	test/run_upgrade_test 9.2:remote 9.4:local 9.5:local 9.6:local
+
+DG = /usr/bin/dg
+DG_EXEC = ${DG} --max-passes 25 --template Dockerfile.template --multispec specs/multispec.yml
+
+generate_dockerfiles:
+	for version in ${VERSIONS}; do \
+		${DG_EXEC} --distro centos-7-x86_64.yaml --multispec-selector version=$${version} --output $${version}/Dockerfile; \
+		${DG_EXEC} --distro rhel-7-x86_64.yaml --multispec-selector version=$${version} --output $${version}/Dockerfile.rhel7; \
+	done

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Choose either the CentOS7 or RHEL7 based image:
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed
 on all provided versions of PostgreSQL.**
 
+Contributing
+--------------------------------
+
+In this repository [distgen](https://github.com/devexp-db/distgen/) is used for generating Dockerfiles. If you'd like update a Dockerfile, please make changes in specs/multispec.yml and/or Dockerfile.template (or other distgen file) and run `make generate_dockerfiles`.
 
 Usage
 ---------------------------------

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -42,7 +42,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 RUN yum install -y centos-release-scl-rh && \
     yum-config-manager --add-repo https://cbs.centos.org/repos/sclo7-rh-postgresql96-rh-candidate/x86_64/os/ && \
     echo gpgcheck=0 >> /etc/yum.repos.d/cbs.centos.org_repos_sclo7-rh-postgresql96-rh-candidate_x86_64_os_.repo && \
-    INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql96 rh-postgresql96-postgresql-contrib nss_wrapper rh-postgresql95-postgresql-server" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper rh-postgresql96 rh-postgresql96-postgresql-contrib rh-postgresql95-postgresql-server" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/latest/Dockerfile.rhel7
+++ b/latest/Dockerfile.rhel7
@@ -44,8 +44,9 @@ RUN yum install -y yum-utils gettext && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql96 rh-postgresql96-postgresql-contrib nss_wrapper rh-postgresql95-postgresql-server" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper rh-postgresql96 rh-postgresql96-postgresql-contrib rh-postgresql95-postgresql-server" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -1,0 +1,65 @@
+version: 1
+
+specs:
+  distroinfo:
+    centos:
+      distros:
+        - centos-7-x86_64
+      org: "centos"
+      prod: "centos7"
+      repo_enable_reason: ""
+      environment_setup: yum install -y centos-release-scl-rh && \
+      maintainer: "SoftwareCollections.org <sclorg@redhat.com>"
+      staging_repo_setup: >-4
+              yum-config-manager --add-repo https://cbs.centos.org/repos/sclo7-rh-postgresql96-rh-candidate/x86_64/os/ && \
+              echo gpgcheck=0 >> /etc/yum.repos.d/cbs.centos.org_repos_sclo7-rh-postgresql96-rh-candidate_x86_64_os_.repo && \
+
+    rhel7:
+       distros:
+         - rhel-7-x86_64
+       org: "rhscl"
+       prod: "rhel7"
+       repo_enable_reason: |-
+         # rhel-7-server-ose-3.2-rpms is enabled for nss_wrapper until this pkg is
+         # in base RHEL
+       environment_setup: >-4
+           yum install -y yum-utils gettext && \
+               yum-config-manager --disable \* &> /dev/null && \
+               yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+               yum-config-manager --enable rhel-7-server-rpms && \
+               yum-config-manager --enable rhel-7-server-optional-rpms && \
+       maintainer: ""
+       staging_repo_setup: ""
+       rhscl3_introduced:
+         - "9.6"
+
+  version:
+    "9.4":
+      version: "9.4"
+      prev_version: "9.2"
+      short: "94"
+      pkgs: "rh-postgresql94 rh-postgresql94-postgresql-contrib postgresql92-postgresql-server rh-postgresql94-postgresql-upgrade"
+      enabled_collection: "rh-postgresql94"
+      openshift_tags: "database,postgresql,postgresql94,rh-postgresql94"
+      redhat_component: "rh-postgresql94-docker"
+      stable: True
+
+    "9.5":
+      version: "9.5"
+      prev_version: "9.4"
+      short: "95"
+      pkgs: "rh-postgresql95 rh-postgresql95-postgresql-contrib rh-postgresql94-postgresql-server"
+      enabled_collection: "rh-postgresql95"
+      openshift_tags: "database,postgresql,postgresql95,rh-postgresql95"
+      redhat_component: "rh-postgresql95-docker"
+      stable: True
+
+    "9.6":
+      version: "9.6"
+      prev_version: "9.5"
+      short: "96"
+      pkgs: "rh-postgresql96 rh-postgresql96-postgresql-contrib rh-postgresql95-postgresql-server"
+      enabled_collection: "rh-postgresql96"
+      openshift_tags: "database,postgresql,postgresql96,rh-postgresql96"
+      redhat_component: "rh-postgresql96-docker"
+      stable: False


### PR DESCRIPTION
In this PR it is shown how [distgen] (https://github.com/devexp-db/distgen) can be used to generate Dockerfiles for multiple versions and distributions. We tried to minimize the differences between actual and generated Dockerfiles.

WIP: We still need to figure out how to prevent changes in generated Dockerfiles - e.g warn user when they try to push commits on generated Dockerfiles without specs modified.