### PR TITLE
tests: do not set default $OS

### DIFF
--- a/test/pg-test-lib.sh
+++ b/test/pg-test-lib.sh
@@ -1,4 +1,3 @@
-: ${OS=centos7}
 DEBUG=false
 
 info  () { echo >&2 " * $*" ; }


### PR DESCRIPTION
We check whether `$OS`is set in the run-test script. If we fallback to a default before that check the test does not make any sense.