### PR TITLE
Let the username/password validation on PostgreSQL server

### DIFF
--- a/src/root/usr/share/container-scripts/postgresql/common.sh
+++ b/src/root/usr/share/container-scripts/postgresql/common.sh
@@ -23,9 +23,6 @@ export POSTGRESQL_CONFIG_FILE=$HOME/openshift-custom-postgresql.conf
 
 postinitdb_actions=
 
-psql_identifier_regex='^[a-zA-Z_][a-zA-Z0-9_]*$'
-psql_password_regex='^[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]+$'
-
 # match . files when moving userdata below
 shopt -s dotglob
 # extglob enables the !(userdata) glob pattern below.
@@ -39,11 +36,9 @@ function usage() {
   cat >&2 <<EOF
 For general container run, you must either specify the following environment
 variables:
-  POSTGRESQL_USER (regex: '$psql_identifier_regex')
-  POSTGRESQL_PASSWORD (regex: '$psql_password_regex')
-  POSTGRESQL_DATABASE (regex: '$psql_identifier_regex')
+  POSTGRESQL_USER  POSTGRESQL_PASSWORD  POSTGRESQL_DATABASE
 Or the following environment variable:
-  POSTGRESQL_ADMIN_PASSWORD (regex: '$psql_password_regex')
+  POSTGRESQL_ADMIN_PASSWORD
 Or both.
 
 To migrate data from different PostgreSQL container:
@@ -67,9 +62,6 @@ function check_env_vars() {
   if [[ -v POSTGRESQL_USER || -v POSTGRESQL_PASSWORD || -v POSTGRESQL_DATABASE ]]; then
     # one var means all three must be specified
     [[ -v POSTGRESQL_USER && -v POSTGRESQL_PASSWORD && -v POSTGRESQL_DATABASE ]] || usage
-    [[ "$POSTGRESQL_USER"     =~ $psql_identifier_regex ]] || usage
-    [[ "$POSTGRESQL_PASSWORD" =~ $psql_password_regex   ]] || usage
-    [[ "$POSTGRESQL_DATABASE" =~ $psql_identifier_regex ]] || usage
 {% raw %}
     [ ${#POSTGRESQL_USER}     -le 63 ] || usage "PostgreSQL username too long (maximum 63 characters)"
     [ ${#POSTGRESQL_DATABASE} -le 63 ] || usage "Database name too long (maximum 63 characters)"
@@ -78,7 +70,6 @@ function check_env_vars() {
   fi
 
   if [ -v POSTGRESQL_ADMIN_PASSWORD ]; then
-    [[ "$POSTGRESQL_ADMIN_PASSWORD" =~ $psql_password_regex ]] || usage
     postinitdb_actions+=",admin_pass"
   fi
 

--- a/src/root/usr/share/container-scripts/postgresql/start/set_passwords.sh
+++ b/src/root/usr/share/container-scripts/postgresql/start/set_passwords.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 
+_psql () { psql --set ON_ERROR_STOP=1 "$@" ; }
+
 if [[ ",$postinitdb_actions," = *,simple_db,* ]]; then
-psql --command "ALTER USER \"${POSTGRESQL_USER}\" WITH ENCRYPTED PASSWORD '${POSTGRESQL_PASSWORD}';"
+_psql --set=username="$POSTGRESQL_USER" \
+      --set=password="$POSTGRESQL_PASSWORD" \
+<<< "ALTER USER :\"username\" WITH ENCRYPTED PASSWORD :'password';"
 fi
 
 if [ -v POSTGRESQL_MASTER_USER ]; then
-psql --command "ALTER USER \"${POSTGRESQL_MASTER_USER}\" WITH REPLICATION;"
-psql --command "ALTER USER \"${POSTGRESQL_MASTER_USER}\" WITH ENCRYPTED PASSWORD '${POSTGRESQL_MASTER_PASSWORD}';"
+_psql --set=masteruser="$POSTGRESQL_MASTER_USER" \
+      --set=masterpass="$POSTGRESQL_MASTER_PASSWORD" \
+<<'EOF'
+ALTER USER :"masteruser" WITH REPLICATION;
+ALTER USER :"masteruser" WITH ENCRYPTED PASSWORD :'masterpass';
+EOF
 fi
 
 if [ -v POSTGRESQL_ADMIN_PASSWORD ]; then
-psql --command "ALTER USER \"postgres\" WITH ENCRYPTED PASSWORD '${POSTGRESQL_ADMIN_PASSWORD}';"
+_psql --set=adminpass="$POSTGRESQL_ADMIN_PASSWORD" \
+<<<"ALTER USER \"postgres\" WITH ENCRYPTED PASSWORD :'adminpass';"
 fi

--- a/test/run_test
+++ b/test/run_test
@@ -115,7 +115,7 @@ function get_ip_from_cid() {
 }
 
 function postgresql_cmd() {
-  docker run --rm -e PGPASSWORD="${PASS}" $IMAGE_NAME psql postgresql://$PGUSER@$CONTAINER_IP:5432/"${DB-db}" "$@"
+  docker run --rm -e PGPASSWORD="$PASS" "$IMAGE_NAME" psql "postgresql://$PGUSER@$CONTAINER_IP:5432/${DB-db}" "$@"
 }
 
 function test_connection() {
@@ -160,9 +160,12 @@ function test_postgresql() {
 function create_container() {
   local name=$1 ; shift
   local cargs=${DOCKER_ARGS:-}
+  # TODO: fix all create_container() invocations so that we don't need this,
+  # e.g. multiline DOCKER_ARGS var should end by trailing backslashes
+  cargs=$(echo "$cargs" | tr  '\n' ' ')
   cidfile="$CIDFILE_DIR/$name"
   # create container with a cidfile in a directory for cleanup
-  docker run $cargs --cidfile $cidfile -d $IMAGE_NAME "$@"
+  eval "docker run $cargs --cidfile \$cidfile -d \$IMAGE_NAME \"\$@\""
   echo "Created container $(cat $cidfile)"
 }
 
@@ -228,6 +231,49 @@ function assert_container_creation_fails() {
   fi
 }
 
+
+# assert_container_creation_succeeds NAME [ARGS]
+# ----------------------------------------------
+# Chcek that 'docker run' with IMAGE_NAME succeeds with docker arguments
+# specified as ARGS.
+assert_container_creation_succeeds ()
+{
+  local check_env=false
+  local name=pg-success-"$(ct_random_string)"
+  local PGUSER='' PGPASS=''  DB=''  ADMIN_PASS=
+  local docker_args=
+
+  for arg; do
+    docker_args+=" $(printf "%q" "$arg")"
+    if $check_env; then
+      local env=${arg//=*/}
+      local val=${arg//$env=/}
+      case $env in
+        POSTGRESQL_ADMIN_PASSWORD)  ADMIN_PASS=$val ;;
+        POSTGRESQL_USER)            PGUSER=$val ;;
+        POSTGRESQL_PASSWORD)        PGPASS=$val ;;
+        POSTGRESQL_DATABASE)        DB=$val ;;
+      esac
+      check_env=false
+    elif test "$arg" = -e; then
+      check_env=:
+    fi
+  done
+
+  DOCKER_ARGS=$docker_args create_container "$name"
+
+  if test -n "$PGUSER" && test -n "$PGPASS"; then
+    PGUSER=$PGUSER PASS=$PGPASS DB=$DB test_connection "$name"
+  fi
+
+  if test -n "$ADMIN_PASS"; then
+    PGUSER=postgres PASS=$ADMIN_PASS DB=$DB test_connection "$name"
+  fi
+
+  docker stop "$(get_cid "$name")"
+}
+
+
 function try_image_invalid_combinations() {
   assert_container_creation_fails -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass "$@"
   assert_container_creation_fails -e POSTGRESQL_USER=user -e POSTGRESQL_DATABASE=db "$@"
@@ -240,13 +286,16 @@ function run_container_creation_tests() {
   try_image_invalid_combinations  -e POSTGRESQL_ADMIN_PASSWORD=admin_pass
 
   VERY_LONG_IDENTIFIER="very_long_identifier_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-  assert_container_creation_fails -e POSTGRESQL_USER=0invalid -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -e POSTGRESQL_ADMIN_PASSWORD=admin_pass
+  assert_container_creation_fails -e POSTGRESQL_USER= -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -e POSTGRESQL_ADMIN_PASSWORD=admin_pass
   assert_container_creation_fails -e POSTGRESQL_USER=$VERY_LONG_IDENTIFIER -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -e POSTGRESQL_ADMIN_PASSWORD=admin_pass
-  assert_container_creation_fails -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD="\"" -e POSTGRESQL_DATABASE=db -e POSTGRESQL_ADMIN_PASSWORD=admin_pass
-  assert_container_creation_fails -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=9invalid -e POSTGRESQL_ADMIN_PASSWORD=admin_pass
+  assert_container_creation_succeeds -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD="\"" -e POSTGRESQL_DATABASE=db -e POSTGRESQL_ADMIN_PASSWORD=admin_pass
+  assert_container_creation_succeeds -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=9invalid -e POSTGRESQL_ADMIN_PASSWORD=admin_pass
   assert_container_creation_fails -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=$VERY_LONG_IDENTIFIER -e POSTGRESQL_ADMIN_PASSWORD=admin_pass
-  assert_container_creation_fails -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -e POSTGRESQL_ADMIN_PASSWORD="\""
+  assert_container_creation_succeeds -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -e POSTGRESQL_ADMIN_PASSWORD="\""
   echo "  Success!"
+
+  assert_container_creation_succeeds -e POSTGRESQL_ADMIN_PASSWORD="the @password"
+  assert_container_creation_succeeds -e POSTGRESQL_PASSWORD="the pass" -e POSTGRESQL_USER="the user" -e POSTGRESQL_DATABASE="the db"
 }
 
 function test_config_option() {


### PR DESCRIPTION
Psql has a feature guarding against sql injection (psql --set),
so use this and don't try to add some artificial limits on our
own.  This has a benefits like:

 - we don't have to care about sql injections
 - our passwords can contain spaces, and other special
   characters
 - simplified "usage" output

The downside is that the rejection of wrongly specified
passwords/username is a delayed.  But because PostgreSQL itself
doesn't create any artificial requirements on those values, it is
pretty unlikely.