### PR TITLE
tests: print oc logs on failure

### DIFF
--- a/test/run-openshift
+++ b/test/run-openshift
@@ -338,6 +338,9 @@ function test_postgresql_ephemeral_redeploy() {
 }
 
 ct_os_cluster_up
+# Print oc logs on failure
+ct_os_enable_print_logs
+
 test_postgresql_pure_image "${IMAGE_NAME}"
 test_postgresql_template "${IMAGE_NAME}"
 test_postgresql_ephemeral_redeploy "${IMAGE_NAME}"


### PR DESCRIPTION
This change should help with looking into what went wrong during image testing on Openshift.