### PR TITLE
tests: Fix centos failures due to postgresql10 being unreleased on rhel

### DIFF
--- a/test/run-openshift
+++ b/test/run-openshift
@@ -170,7 +170,9 @@ function test_postgresql_update() {
   done
 
   if docker pull "$old_image" 2>/dev/null; then
-    $released
+    # Check if we do not have a stale unreleased versions list
+    # Fail only on rhel, on centos the image is likely already released
+    $released || [ "$OS" = "centos7" ]
   else
     # We can not test against released image.
     ! $released


### PR DESCRIPTION
Fixed by removing one of the if branches. Was there a reason to have it fail when an older image is available?