### PR TITLE
run-openshift: better check whether image was released

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 BASE_IMAGE_NAME = postgresql
 VERSIONS = 9.4 9.5 9.6 10
 OPENSHIFT_NAMESPACES = 9.2
-NOT_RELEASED_VERSIONS = 10
+NOT_RELEASED_VERSIONS =
 
 # HACK:  Ensure that 'git pull' for old clones doesn't cause confusion.
 # New clones should use '--recursive'.

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -82,4 +82,3 @@ specs:
       stable: False
       has_devel_repo:
         centos: True
-        rhel: brew

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -40,7 +40,6 @@ specs:
       common_image_name: "{{ spec.org }}/postgresql-94-{{ spec.prod }}"
       rhel_image_name: "rhscl/postgresql-94-rhel7"
       centos_image_name: "centos/postgresql-94-centos7"
-      stable: True
 
     "9.5":
       version: "9.5"
@@ -53,7 +52,6 @@ specs:
       common_image_name: "{{ spec.org }}/postgresql-95-{{ spec.prod }}"
       rhel_image_name: "rhscl/postgresql-95-rhel7"
       centos_image_name: "centos/postgresql-95-centos7"
-      stable: True
 
     "9.6":
       version: "9.6"
@@ -66,7 +64,6 @@ specs:
       common_image_name: "{{ spec.org }}/postgresql-96-{{ spec.prod }}"
       rhel_image_name: "rhscl/postgresql-96-rhel7"
       centos_image_name: "centos/postgresql-96-centos7"
-      stable: True
 
     "10":
       version: "10"
@@ -79,6 +76,5 @@ specs:
       common_image_name: "{{ spec.org }}/postgresql-10-{{ spec.prod }}"
       rhel_image_name: "rhscl/postgresql-10-rhel7"
       centos_image_name: "centos/postgresql-10-centos7"
-      stable: False
       has_devel_repo:
         centos: True

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -50,7 +50,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 {{ spec.repo_enable_reason }}
 {% endif %}
 RUN {{ spec.environment_setup }}
-{% if not spec.stable and spec.has_devel_repo %}
+{% if spec.has_devel_repo %}
   {% if config.os.id == 'centos' and spec.has_devel_repo.centos %}
     yum-config-manager --add-repo https://cbs.centos.org/repos/sclo7-rh-postgresql{{ spec.version }}-rh-candidate/x86_64/os/ && \
     echo gpgcheck=0 >> /etc/yum.repos.d/cbs.centos.org_repos_sclo7-rh-postgresql{{ spec.version }}-rh-candidate_x86_64_os_.repo && \

--- a/test/run-openshift
+++ b/test/run-openshift
@@ -189,10 +189,10 @@ function test_postgresql_update() {
     # Check if we do not have a stale unreleased versions list
     # Fail only on rhel, on centos the image is likely already released
     $released || [ "$OS" = "centos7" ]
+  elif $released; then
+    false "image '$old_image' should already be available"
   else
-    # We can not test against released image.
-    ! $released
-    return
+    return # not yet released image, skip
   fi
 
 


### PR DESCRIPTION
Needed because `! true` actually doesn't exit with `set -e` shell.