### PR TITLE
make upgrade code more general

### DIFF
--- a/src/root/usr/share/container-scripts/postgresql/common.sh
+++ b/src/root/usr/share/container-scripts/postgresql/common.sh
@@ -259,8 +259,8 @@ run_pgupgrade ()
     old_collection=rh-postgresql$old_raw_version
   fi
 
-  old_pgengine=/opt/rh/$old_collection/root/usr/bin
-  new_pgengine=/opt/rh/rh-postgresql${new_raw_version}/root/usr/bin
+  old_pgengine=${POSTGRESQL_PREV_BINDIR:-/opt/rh/$old_collection/root/usr/bin}
+  new_pgengine=${POSTGRESQL_BINDIR:-/opt/rh/rh-postgresql${new_raw_version}/root/usr/bin}
   PGDATA_new="${PGDATA}-new"
 
   printf >&2 "\n==========  \$PGDATA upgrade: %s -> %s  ==========\n\n" \

--- a/test/run_test
+++ b/test/run_test
@@ -569,15 +569,8 @@ $volume_options
 
 run_upgrade_test ()
 {
-    local upgrade_path="none 9.2 9.4 9.5 9.6 10 none" prev= act=
-    for act in $upgrade_path; do
-        if test "$act" = $VERSION; then
-            break
-        fi
-        prev=$act
-    done
-    test "$prev" != none
-
+    local prev=
+    prev=$(docker inspect $IMAGE_NAME | grep -m 1 -oP "POSTGRESQL_PREV_VERSION=\\K[0-9.]+")
     # TODO: We run this script from $VERSION directory, through test/run symlink.
     test/run_upgrade_test "$prev:remote" "$VERSION:local"
 }


### PR DESCRIPTION
Introduce a way for overriding the default SCL-specific paths in `run_pgupgrade`
via `$POSTGRESQL_PREV_BINDIR` and `POSTGRESQL_BINDIR` so that images
that are not using SCLs (eg. Fedora) can run the automatic upgrade feature.

Allow any combination of previous and current version of postgresql in `run_upgrade_test`

@praiskup PTAL