### PR TITLE
Generate Fedora Dockerfile using distgen.

### DIFF
--- a/manifest.sh
+++ b/manifest.sh
@@ -13,9 +13,6 @@ DISTGEN_RULES="
 
     src=src/root/usr/share/container-scripts/postgresql/common.sh
     dest=root/usr/share/container-scripts/postgresql/common.sh;
-
-    src=src/Dockerfile.fedora
-    dest=Dockerfile.fedora;
 "
 
 # Files containing distgen directives, which are used for each
@@ -25,7 +22,10 @@ DISTGEN_MULTI_RULES="
     dest=Dockerfile;
 
     src=src/Dockerfile
-    dest=Dockerfile.rhel7
+    dest=Dockerfile.rhel7;
+
+    src=src/Dockerfile.fedora
+    dest=Dockerfile.fedora;
 "
 
 # Symbolic links

--- a/manifest.sh
+++ b/manifest.sh
@@ -12,7 +12,10 @@ DISTGEN_RULES="
     dest=root/usr/share/container-scripts/postgresql/README.md;
 
     src=src/root/usr/share/container-scripts/postgresql/common.sh
-    dest=root/usr/share/container-scripts/postgresql/common.sh
+    dest=root/usr/share/container-scripts/postgresql/common.sh;
+
+    src=src/Dockerfile.fedora
+    dest=Dockerfile.fedora;
 "
 
 # Files containing distgen directives, which are used for each

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -27,6 +27,9 @@ specs:
                prepare-yum-repositories rhel-server-rhscl-7-rpms && \
        rhscl_version:
          development: 3.1
+    fedora:
+      distros:
+        - fedora-29-x86_64
 
   version:
     "9.5":
@@ -69,3 +72,9 @@ specs:
       latest_fedora: "f29"
       has_devel_repo:
         centos: True
+
+matrix:
+  exclude:
+    - distros:
+        - fedora-29-x86_64
+      version: "9.5"

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -40,6 +40,7 @@ specs:
       common_image_name: "{{ spec.org }}/postgresql-95-{{ spec.prod }}"
       rhel_image_name: "rhscl/postgresql-95-rhel7"
       centos_image_name: "centos/postgresql-95-centos7"
+      latest_fedora: "f25"
 
     "9.6":
       version: "9.6"
@@ -52,6 +53,7 @@ specs:
       common_image_name: "{{ spec.org }}/postgresql-96-{{ spec.prod }}"
       rhel_image_name: "rhscl/postgresql-96-rhel7"
       centos_image_name: "centos/postgresql-96-centos7"
+      latest_fedora: "f27"
 
     "10":
       version: "10"
@@ -64,5 +66,6 @@ specs:
       common_image_name: "{{ spec.org }}/postgresql-10-{{ spec.prod }}"
       rhel_image_name: "rhscl/postgresql-10-rhel7"
       centos_image_name: "centos/postgresql-10-centos7"
+      latest_fedora: "f29"
       has_devel_repo:
         centos: True

--- a/src/Dockerfile.fedora
+++ b/src/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:26
+FROM registry.fedoraproject.org/{{ spec.latest_fedora }}/s2i-core:latest
 
 # PostgreSQL image for OpenShift.
 # Volumes:
@@ -12,43 +12,40 @@ FROM registry.fedoraproject.org/fedora:26
 
 ENV NAME=postgresql \
     VERSION=0 \
-    RELEASE=1 \
     ARCH=x86_64 \
     \
-    POSTGRESQL_VERSION=9.6 \
-    POSTGRESQL_PREV_VERSION=9.5 \
+    POSTGRESQL_VERSION={{ spec.version }} \
+    POSTGRESQL_PREV_VERSION={{ spec.prev_version }} \
     HOME=/var/lib/pgsql \
-    PGUSER=postgres
+    PGUSER=postgres \
+    APP_DATA=/opt/app-root
 
 ENV SUMMARY="PostgreSQL is an advanced Object-Relational database management system" \
     DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
 The image contains the client and server programs that you'll need to \
 create, run, maintain and access a PostgreSQL DBMS server."
 
-LABEL summary=$SUMMARY \
+LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
-      io.k8s.display-name="PostgreSQL 9.6" \
+      io.k8s.display-name="PostgreSQL {{ spec.version }}" \
       io.openshift.expose-services="5432:postgresql" \
-      io.openshift.tags="database,postgresql,postgresql96" \
+      io.openshift.tags="database,postgresql,postgresql{{ spec.short }}" \
       com.redhat.component="$NAME" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       name="$FGC/$NAME" \
       version="0" \
-      release="$RELEASE.$DISTTAG" \
-      architecture="$ARCH" \
-      usage="docker run -d --name postgresql_database -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -p 5432:5432 $FGC/$NAME" \
-      help="/help.1"
+      usage="docker run -d --name postgresql_database -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -p 5432:5432 $FGC/$NAME"
 
 EXPOSE 5432
 
-ADD root /
+COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN INSTALL_PKGS="rsync tar gettext bind-utils postgresql-server postgresql-contrib nss_wrapper " && \
-    INSTALL_PKGS+="findutils python2 " && \
+    INSTALL_PKGS+="findutils python2 xz" && \
     dnf -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all && \
@@ -60,7 +57,15 @@ RUN INSTALL_PKGS="rsync tar gettext bind-utils postgresql-server postgresql-cont
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql
 
+COPY root /
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
 VOLUME ["/var/lib/pgsql/data"]
+
+# {APP_DATA} needs to be accessed by postgres user while s2i assembling
+# postgres user changes permissions of files in APP_DATA during assembling
+RUN /usr/libexec/fix-permissions ${APP_DATA} && \
+    usermod -a -G root postgres
 
 USER 26
 

--- a/test/run-openshift
+++ b/test/run-openshift
@@ -159,8 +159,8 @@ function test_postgresql_template() {
 function test_postgresql_update() {
   local image_name=$1; shift
   local template=$1
-  local image_name_no_namespace=${image_name##*/}
-  local service_name=$image_name_no_namespace
+  local image_name_no_registry=${image_name#*/}
+  local service_name=${image_name_no_registry#*/}
   local user="testu" pass="testp" db="testdb"
   local registry="" old_image="" pod_ip=""
   local version released=:
@@ -174,7 +174,7 @@ function test_postgresql_update() {
       ;;
   esac
 
-  old_image="$registry/$image_name"
+  old_image="$registry/$image_name_no_registry"
 
   for version in $NOT_RELEASED_VERSIONS; do
     case $image_name in

--- a/test/run_test
+++ b/test/run_test
@@ -635,6 +635,8 @@ $volume_options
 
 run_upgrade_test ()
 {
+    [ "${OS}" == "fedora" ] && return 0
+
     local upgrade_path="none 9.2 9.4 9.5 9.6 10 none" prev= act=
     for act in $upgrade_path; do
         if test "$act" = $VERSION; then
@@ -650,6 +652,8 @@ run_upgrade_test ()
 
 run_migration_test ()
 {
+    [ "${OS}" == "fedora" ] && return 0
+
     local from_version
     local upgrade_path="9.2 9.4 9.5 9.6 10"
 


### PR DESCRIPTION
Generate Fedora Dockerfile using distgen.

Remove release label - in Fedora it's updated automatically by
build system.

Remove arch label - 'Optional: if omitted, it will be built for
all supported Fedora Architectures'

Skip upgrade and migration test for Fedora images - uses
completely different system how to get name of an image which
contains previous version of postgresql

+ make fedora Dockerfile more similar to other OSes

@pkubatrh @praiskup Please take a look and merge.