### PR TITLE
Remove volume from dockerfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -87,8 +87,6 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-VOLUME ["/var/lib/pgsql/data"]
-
 # {APP_DATA} needs to be accessed by postgres user while s2i assembling
 # postgres user changes permissions of files in APP_DATA during assembling
 RUN /usr/libexec/fix-permissions ${APP_DATA} && \


### PR DESCRIPTION
This PR removes the volume definition from the dockerfile. Removing the volume will allow us to use this docker images on Openshift Online.

### The issue with using volume in Dockerfile
Running the `postgresql-96-centos7`  on https://che.openshift.io (which runs on openshift online) fails with the following error because of the volume definition in the dockerfile
```
pulling image "registry.centos.org/postgresql/postgresql:9.6"
Successfully pulled image "registry.centos.org/postgresql/postgresql:9.6"
Error: Error response from daemon: create bf02f38276729574b6586e049129587cdeb36a951e4d1d38129ec8b8bb8a955d: error while creating volume path '/var/lib/docker/volumes/bf02f38276729574b6586e049129587cdeb36a951e4d1d38129ec8b8bb8a955d/_data': mkdir /var/lib/docker/volumes/bf02f38276729574b6586e049129587cdeb36a951e4d1d38129ec8b8bb8a955d: permission denied
```

### What have we tried?
- According to https://github.com/openshift/origin/issues/16211#issuecomment-350819976, I tried to mount a volume in che but that too doesn't seem to work.
- I created a new image after removing the dockerfile (https://hub.docker.com/r/jarifibrahim/postgres-no-volume/) and it works on che.



I understand that this is a breaking change but the user can manually mount the volume via 
`docker run -v` command. 

The same change was done for MySQL image (https://github.com/sclorg/mysql-container/blob/master/5.7/Dockerfile#L73) since it wasn't working on openshift online.

See https://github.com/redhat-developer/rh-che/pull/1086