### PR TITLE
Do not test against 9.2 image anymore

### DIFF
--- a/test/run_test
+++ b/test/run_test
@@ -637,7 +637,7 @@ run_upgrade_test ()
 {
     [ "${OS}" == "fedora" ] && return 0
 
-    local upgrade_path="none 9.2 9.4 9.5 9.6 10 none" prev= act=
+    local upgrade_path="none 9.4 9.5 9.6 10 none" prev= act=
     for act in $upgrade_path; do
         if test "$act" = $VERSION; then
             break
@@ -655,7 +655,7 @@ run_migration_test ()
     [ "${OS}" == "fedora" ] && return 0
 
     local from_version
-    local upgrade_path="9.2 9.4 9.5 9.6 10"
+    local upgrade_path="9.4 9.5 9.6 10"
 
     for from_version in $upgrade_path; do
         # Do not test migration from $VERSION:remote to $VERSION:local


### PR DESCRIPTION
Workaround for [BZ#1655214](https://bugzilla.redhat.com/show_bug.cgi?id=1655214) to get postgresql tests passing on RHEL with Docker rpms.

We could wait for the fix in Docker rpms but do we want to test upgrades and migrations from images we have not supported for a long time anyway?