### PR TITLE
exclude container user's id when setting up passwd file

### DIFF
--- a/src/root/usr/share/container-scripts/postgresql/common.sh
+++ b/src/root/usr/share/container-scripts/postgresql/common.sh
@@ -137,7 +137,7 @@ function generate_postgresql_recovery_config() {
 function generate_passwd_file() {
   export USER_ID=$(id -u)
   export GROUP_ID=$(id -g)
-  grep -v ^postgres /etc/passwd > "$HOME/passwd"
+  grep -v -e ^postgres -e ^$USER_ID /etc/passwd > "$HOME/passwd"
   echo "postgres:x:${USER_ID}:${GROUP_ID}:PostgreSQL Server:${HOME}:/bin/bash" >> "$HOME/passwd"
   export LD_PRELOAD=libnss_wrapper.so
   export NSS_WRAPPER_PASSWD=${HOME}/passwd

--- a/test/run-openshift
+++ b/test/run-openshift
@@ -174,7 +174,7 @@ function test_postgresql_update() {
       ;;
   esac
 
-  old_image="$registry/$image_name_no_registry"
+  old_image="$registry/$image_name"
 
   for version in $NOT_RELEASED_VERSIONS; do
     case $image_name in

--- a/test/run-openshift
+++ b/test/run-openshift
@@ -273,7 +273,7 @@ function test_postgresql_replication() {
   check_postgresql_data "$image_name" "$user" "$pass" "$db" "$slave_ip"
 
   : "Redeploying slave node"
-  oc deploy "$slave_service_name" --latest
+  oc rollout latest "$slave_service_name"
   ct_os_wait_pod_ready "$slave_service_name-3" 60
   slave_name=$(ct_os_get_pod_name "$slave_service_name")
   slave_ip=$(ct_os_get_pod_ip "$slave_name")
@@ -318,7 +318,7 @@ function test_postgresql_persistent_redeploy() {
   insert_postgresql_data "$image_name" "$user" "$pass" "$db" "$pod_ip"
 
   : "Redeploying pod"
-  oc deploy "$service_name" --latest
+  oc rollout latest "$service_name"
   : "Waiting for a few seconds while the pod gets restarted"
   sleep 5
 
@@ -356,7 +356,7 @@ function test_postgresql_ephemeral_redeploy() {
   insert_postgresql_data "$image_name" "$user" "$pass" "$db" "$pod_ip"
 
   : "Redeploying pod"
-  oc deploy "$service_name" --latest
+  oc rollout latest "$service_name"
   : "Waiting for a few seconds while the pod gets restarted"
   sleep 5
 


### PR DESCRIPTION
When a container is run with a recent enough podman version and using the --user cli argument the /etc/passwd file inside the container includes a line with the user defined via --user:

```
$ podman run --rm -ti --user 1001 rhel7 bash -c "cat /etc/passwd | grep 1001"
1001:x:1001:0:container user:/:/bin/sh
```

Since postgresql creates a postgres user with the user id of the container user we need to exclude the passwd line containing said user from the generated passwd file else the initial database will not be owned by the postgres user.