### PR TITLE
[run-postgresql] Make the DB initialization atomic

### DIFF
--- a/src/root/usr/bin/run-postgresql
+++ b/src/root/usr/bin/run-postgresql
@@ -20,7 +20,9 @@ generate_postgresql_config
 # Is this brand new data volume?
 PG_INITIALIZED=false
 
-if [ ! -f "$PGDATA/postgresql.conf" ]; then
+# Perform the DB initialization as an atomic operation,
+# IOW either complete all of its phases or redo it
+if [ "$PG_INITIALIZED" == "false" ]; then
   initialize_database
   PG_INITIALIZED=:
 else


### PR DESCRIPTION
(complete all of its parts or retry it if some failed)

Might possibly fix: https://github.com/sclorg/postgresql-container/issues/309 (Didn't test it though)

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>