### PR TITLE
[KEYCLOAK-8742] [run-postgresql] Make the DB initialization atomic

### DIFF
--- a/src/root/usr/bin/run-postgresql
+++ b/src/root/usr/bin/run-postgresql
@@ -20,8 +20,14 @@ generate_postgresql_config
 # Is this brand new data volume?
 PG_INITIALIZED=false
 
-if [ ! -f "$PGDATA/postgresql.conf" ]; then
-  initialize_database
+if [ ! -f "${PGDATA}/postgresql.conf" ]; then
+  # Minimize the race condition of unfinished DB initialization vs pod restart
+  # First initialize the DB into temporary directory
+  TEMP_PGDATA=$(mktemp -d $(printf '%0.sX' {1..32}))
+  initialize_database "${TEMP_PGDATA}"
+  # If DB initialization succeeded, move the content of temporary directory to
+  # final PGDATA & set PG_INITIALIZED flag
+  mv -T "${TEMP_PGDATA}" "${PGDATA}"
   PG_INITIALIZED=:
 else
   try_pgupgrade


### PR DESCRIPTION
Either complete the DB init as a whole, or start it from the beginning
if the pod got restarted while DB init was in progress, but didn't finish
properly

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Fixes: https://github.com/sclorg/postgresql-container/issues/309