### PR TITLE
Tighten (and document) the permission setup by fix-permissions

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -76,8 +76,7 @@ RUN {{ spec.environment_setup }}
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
     mkdir -p /var/lib/pgsql/data && \
-    /usr/libexec/fix-permissions /var/lib/pgsql && \
-    /usr/libexec/fix-permissions /var/run/postgresql
+    /usr/libexec/fix-permissions /var/lib/pgsql /var/run/postgresql
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
@@ -97,10 +96,19 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
 {% endif %}
 VOLUME ["/var/lib/pgsql/data"]
 
-# {APP_DATA} needs to be accessed by postgres user while s2i assembling
-# postgres user changes permissions of files in APP_DATA during assembling
-RUN /usr/libexec/fix-permissions ${APP_DATA} && \
-    usermod -a -G root postgres
+# S2I permission fixes
+# --------------------
+# 1. unless specified otherwise (or - equivalently - we are in OpenShift), s2i
+#    build process would be executed as 'uid=26(postgres) gid=26(postgres)'.
+#    Such process wouldn't be able to execute the default 'assemble' script
+#    correctly (it transitively executes 'fix-permissions' script).  So let's
+#    add the 'postgres' user into 'root' group here
+#
+# 2. we call fix-permissions on $APP_DATA here directly (UID=0 during build
+#    anyways) to assure that s2i process is actually able to _read_ the
+#    user-specified scripting.
+RUN usermod -a -G root postgres && \
+    /usr/libexec/fix-permissions --read-only "$APP_DATA"
 
 USER 26
 

--- a/src/Dockerfile.fedora
+++ b/src/Dockerfile.fedora
@@ -51,8 +51,7 @@ RUN INSTALL_PKGS="rsync tar gettext bind-utils postgresql-server postgresql-cont
     dnf clean all && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
     mkdir -p /var/lib/pgsql/data && \
-    /usr/libexec/fix-permissions /var/lib/pgsql && \
-    /usr/libexec/fix-permissions /var/run/postgresql
+    /usr/libexec/fix-permissions /var/lib/pgsql /var/run/postgresql
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql
@@ -62,10 +61,19 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
 VOLUME ["/var/lib/pgsql/data"]
 
-# {APP_DATA} needs to be accessed by postgres user while s2i assembling
-# postgres user changes permissions of files in APP_DATA during assembling
-RUN /usr/libexec/fix-permissions ${APP_DATA} && \
-    usermod -a -G root postgres
+# S2I permission fixes
+# --------------------
+# 1. unless specified otherwise (or - equivalently - we are in OpenShift), s2i
+#    build process would be executed as 'uid=26(postgres) gid=26(postgres)'.
+#    Such process wouldn't be able to execute the default 'assemble' script
+#    correctly (it transitively executes 'fix-permissions' script).  So let's
+#    add the 'postgres' user into 'root' group here
+#
+# 2. we call fix-permissions on $APP_DATA here directly (UID=0 during build
+#    anyways) to assure that s2i process is actually able to _read_ the
+#    user-specified scripting.
+RUN usermod -a -G root postgres && \
+    /usr/libexec/fix-permissions --read-only "$APP_DATA"
 
 USER 26
 

--- a/src/root/usr/libexec/fix-permissions
+++ b/src/root/usr/libexec/fix-permissions
@@ -1,7 +1,39 @@
 #!/bin/sh
-# Fix permissions on the given directory to allow group read/write of 
-# regular files and execute of directories.
-find "$1" -exec chown postgres {} \;
-find "$1" -exec chgrp 0 {} \;
-find "$1" -exec chmod g+rw {} \;
-find "$1" -type d -exec chmod g+x {} +
+
+documentation="\
+Recursively fix permissions on the given directories to allow GID=0
+read/write regular files and read/write/execute directories.
+
+To run this command, you have to be in the group root=0!"
+
+uid=26
+write=w
+
+usage ()
+{
+    cat >&2 <<EOF
+$0: Error: ${1-usage error}
+
+Usage: $0 [--read-only] DIR [DIR ..]
+
+$documentation
+EOF
+    exit 1
+}
+
+while test $# -gt 0; do
+    case $1 in
+    --read-only) write= ; shift ;;
+    *) break ;;
+    esac
+done
+
+test $# -eq 0 && usage "no DIR specified"
+
+for dir; do
+    test -d "$dir" || usage "no such directory '$dir'"
+    echo >&2 "fixing permissions on '$dir' directory"
+    find "$dir" -exec chown "$uid:0" {} \;
+    find "$dir" -exec chmod "g+r$write" {} \;
+    find "$dir" -type d -exec chmod g+x {} +
+done

--- a/src/s2i/bin/assemble
+++ b/src/s2i/bin/assemble
@@ -11,4 +11,4 @@ echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
 # Fix source directory permissions
-/usr/libexec/fix-permissions ./
+/usr/libexec/fix-permissions --read-only ./


### PR DESCRIPTION
There's no need to have write-able $APP_DATA, so tighten this.
Also, I keep re-observing the reasons why we add 'postgres' user
into 'root' group all the time -- so let's have this documented as
well.