### PR TITLE
re-set 'set -e' after sourcing extension-hooks

### DIFF
--- a/src/root/usr/share/container-scripts/postgresql/common.sh
+++ b/src/root/usr/share/container-scripts/postgresql/common.sh
@@ -425,6 +425,7 @@ process_extending_files()
       if test -f "$file"; then
         echo "=> sourcing $file ..."
         source "$file"
+        set -e # ensure that users don't mistakenly change this
         break
       fi
     done


### PR DESCRIPTION
Related: #297