### PR TITLE
[KEYCLOAK-8742] Recover if initdb previously failed or got interrupted 

### DIFF
--- a/examples/s2i-dump-data/.s2i/bin/assemble
+++ b/examples/s2i-dump-data/.s2i/bin/assemble
@@ -16,6 +16,9 @@ test ! -f "$PGDATA/postgresql.conf"
 touch "$POSTGRESQL_CONFIG_FILE"
 
 initialize_database
+if [ "$?" -ne "0" ]; then
+  recover_invalid_initdb
+fi
 
 # start local PostgreSQL server (wait with '-w')
 pg_ctl -w start -o "-h ''"

--- a/src/root/usr/bin/run-postgresql
+++ b/src/root/usr/bin/run-postgresql
@@ -20,11 +20,22 @@ generate_postgresql_config
 # Is this brand new data volume?
 PG_INITIALIZED=false
 
-if [ ! -f "$PGDATA/postgresql.conf" ]; then
+if [ ! -f "${PGDATA}/postgresql.conf" ]; then
   initialize_database
-  PG_INITIALIZED=:
+  if [ "$?" -eq "0" ]; then
+    PG_INITIALIZED=:
+  # Recover if PostgreSQL database cluster initialization failed
+  else
+    recover_invalid_initdb
+  fi
 else
-  try_pgupgrade
+  # Recover from the case when PostgreSQL pod was previously restarted sooner
+  # than the database cluster initialization process has had chance to finish
+  if [ "${PG_INITIALIZED}" == "false" ]; then
+    recover_invalid_initdb
+  else
+    try_pgupgrade
+  fi
 fi
 
 pg_ctl -w start -o "-h ''"


### PR DESCRIPTION
(PostgreSQL pod got restarted sooner than initdb has had chance to finish)

Fixes: https://github.com/sclorg/postgresql-container/issues/309
Replacement for: https://github.com/sclorg/postgresql-container/pull/312

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>