### PR TITLE
make livenessProbe to return always true

### DIFF
--- a/src/root/usr/libexec/check-container
+++ b/src/root/usr/libexec/check-container
@@ -9,31 +9,19 @@
 
 test -z "$ENABLED_COLLECTIONS" || . scl_source enable $ENABLED_COLLECTIONS
 
-check=ready
-case $1 in
-    --live) check=live ;;
-esac
+if test x"$1" = "x--live"; then
+    # Since livenessProbe is about to detect container deadlocks, and we
+    # so far don't know about real deadlocks to be detected -- we keep
+    # liveness probe to report that container is always ready (as long as
+    # we are able to execute shell, enable collections, etc., which is
+    # good for container sanity testing anyways).
+    exit 0
+fi
 
-while true; do
-    # Wait until the /bin/postgres is executed.
-    case $(readlink -f /proc/1/exe) in
-        *bash) sleep 0.2; continue ;;
-        *) break ;;
-    esac
-done
-
-# Timeout is infinite (openshift template has the timeout pre-set)
+# Readiness check follows, the --timeout is set to "infinite" because it
+# is handled externally (readinessProbe.timeoutSeconds).
 pg_isready -q \
     -h 127.0.0.1 \
     ${POSTGRESQL_USER+-U "$POSTGRESQL_USER"} \
     ${POSTGRESQL_DATABASE+-d "$POSTGRESQL_DATABASE"} \
     --timeout 0
-rc=$?
-
-# we are ready only if the db accepts connections
-test $rc -eq 0 && exit 0
-
-# container is live also during pg cluster start-up
-test $rc -eq 1 && test $check = live && exit 0
-
-exit 1


### PR DESCRIPTION
Since we have no real deadlocks to be detected in livenessProbe
for now, lets have it (effectively) disabled for now.

The liveness probe used to cause issues before, namely because it:
- killed initdb on a rather slow storage
- would pg_upgrade for rather large data directory
- killed pod when PostgreSQL was in crash recovery

Fixes: #313, #309
Relates: #316