### PR TITLE
set assemble user label for openshift

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -29,6 +29,7 @@ LABEL summary="$SUMMARY" \
       io.k8s.display-name="PostgreSQL {{ spec.version }}" \
       io.openshift.expose-services="5432:postgresql" \
       io.openshift.tags="{{ spec.openshift_tags }}" \
+      io.openshift.s2i.assemble-user="26" \
       name="{{ spec.img_name }}" \
       com.redhat.component="{{ spec.redhat_component }}" \
 {% if spec.version not in ["9.4", "9.5", "9.6"] %}


### PR DESCRIPTION
Since latest openshift defaults to running the assemble script under
the default s2i user (1001) when this label is not provided by the image