### PR TITLE
Add support for POSTGRESQL_CREATEUSER_OPTIONS

### DIFF
--- a/src/root/usr/share/container-scripts/postgresql/README.md
+++ b/src/root/usr/share/container-scripts/postgresql/README.md
@@ -62,6 +62,9 @@ initialization by passing `-e VAR=VALUE` to the Docker run command.
 **`POSTGRESQL_USER`**  
        User name for PostgreSQL account to be created
 
+**`POSTGRESQL_CREATEUSER_OPTIONS`**
+       Options passed directly to PostgreSQL's createuser. Default: no options
+
 **`POSTGRESQL_PASSWORD`**  
        Password for the user account
 

--- a/src/root/usr/share/container-scripts/postgresql/common.sh
+++ b/src/root/usr/share/container-scripts/postgresql/common.sh
@@ -179,14 +179,16 @@ host replication all all md5
 EOF
 }
 
+export POSTGRESQL_CREATEUSER_OPTIONS=${POSTGRESQL_CREATEUSER_OPTIONS:-}
+export POSTGRESQL_MASTER_CREATEUSER_OPTIONS=${POSTGRESQL_MASTER_CREATEUSER_OPTIONS:-}
 function create_users() {
   if [[ ",$postinitdb_actions," = *,simple_db,* ]]; then
-    createuser "$POSTGRESQL_USER"
+    createuser "$POSTGRESQL_CREATEUSER_OPTIONS" "$POSTGRESQL_USER"
     createdb --owner="$POSTGRESQL_USER" "$POSTGRESQL_DATABASE"
   fi
 
   if [ -v POSTGRESQL_MASTER_USER ]; then
-    createuser "$POSTGRESQL_MASTER_USER"
+    createuser "$POSTGRESQL_MASTER_CREATEUSER_OPTIONS" "$POSTGRESQL_MASTER_USER"
   fi
 }
 


### PR DESCRIPTION
allows to create users with --createdb permissions for example, which may be used during testing and development **WITHOUT** having to build a customized image.

The values of these variables are directly passed to `createuser`.


Background:
I am using the `centos/postgresql-10-centos7` container with Django which when running `manage.py test` will create a separate database for testing and needs sufficient permissions.

When can we expect to get this merged and a new image on Docker hub to be available? 