### PR TITLE
tests: change lower-or-equal to eq in get_image_id

### DIFF
--- a/test/pg-test-lib.sh
+++ b/test/pg-test-lib.sh
@@ -23,14 +23,14 @@ get_image_id ()
             case $OS in
             rhel7)
                 ns=rhscl
-                if test "$version" -le 92; then
+                if test "$version" -eq 92; then
                     ns=openshift3
                 fi
                 image=registry.access.redhat.com/$ns/postgresql-${version}-rhel7
                 ;;
             centos7)
                 ns=centos
-                if test "$version" -le 92; then
+                if test "$version" -eq 92; then
                     ns=openshift
                 fi
                 local image=docker.io/$ns/postgresql-${1//\./}-centos7


### PR DESCRIPTION
We only need to work with postgresql92 image now (to test upgrade from RHEL7) and not with older images.
This fixes get_image_id for versions 10+ as they would get the "openshift3" namespaced image names generated.