### PR TITLE
Run all tests by default, allow to fail immediately and improve results reporting

### DIFF
--- a/test/run_test
+++ b/test/run_test
@@ -5,6 +5,9 @@
 # IMAGE_NAME specifies the name of the candidate image used for testing.
 # The image has to be available before this script is executed.
 #
+# By default, all the tests are run. For debugging purposes, FAIL_QUICKLY
+# variable can be set to 1, which makes the test-suite to fail right after any
+# of the tests fails.
 
 set -exo nounset
 shopt -s nullglob
@@ -41,6 +44,8 @@ volumes_to_clean=
 images_to_clean=()
 files_to_clean=
 test_dir="$(readlink -f "$(dirname "$0")")"
+test_short_summary=''
+TESTSUITE_RESULT=1
 
 _cleanup_commands_space=
 _cleanup_commands=
@@ -88,6 +93,14 @@ function cleanup() {
   echo "$_cleanup_commands" | while read -r line; do
     eval "$line"
   done
+
+  echo "$test_short_summary"
+
+  if [ $TESTSUITE_RESULT -eq 0 ] ; then
+    echo "Tests for ${IMAGE_NAME} succeeded."
+  else
+    echo "Tests for ${IMAGE_NAME} failed."
+  fi
 }
 trap cleanup EXIT
 
@@ -832,10 +845,18 @@ run_s2i_bake_data_test ()
 }
 
 function run_all_tests() {
+  local suite_result=0
   for test_case in $TEST_LIST; do
     : "Running test $test_case"
-    $test_case
+    if $test_case ; then
+      printf -v test_short_summary "${test_short_summary}[PASSED] $test_case\n"
+    else
+      printf -v test_short_summary "${test_short_summary}[FAILED] $test_case\n"
+      suite_result=1
+      [ -n "${FAIL_QUICKLY:-}" ] && echo "$sum" && return $suite_result
+    fi
   done;
+  return $suite_result
 }
 
 # configuration defaults
@@ -845,3 +866,6 @@ POSTGRESQL_SHARED_BUFFERS=32MB
 
 # Run the chosen tests
 TEST_LIST=${TESTS:-$TEST_LIST} run_all_tests
+
+TESTSUITE_RESULT=0
+echo "All tests passed."


### PR DESCRIPTION
Previously the test-suite failed immediately after some issue was found. This is not good for general verification, where we should see ideally full results, to see how badly the image is broken. However, for debugging purposes, it is better to see the tests failed right away, so for that purpose, there is `FAIL_QUICKLY` that can be set and tests then fail quickly.

It was also not easy to tell from the test log whether the tests failed, other than checking the exit code. Seeing a clear message that the tests failed should make it more clear.