### PR TITLE
fix Fedora builds

### DIFF
--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -53,7 +53,7 @@ specs:
            yum -y reinstall tzdata && \
     fedora:
       distros:
-        - fedora-29-x86_64
+        - fedora-31-x86_64
 
   version:
     "9.6":
@@ -95,5 +95,4 @@ matrix:
   exclude:
     - distros:
         - rhel-8-x86_64
-        - fedora-29-x86_64
       version: "12"

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -56,17 +56,6 @@ specs:
         - fedora-29-x86_64
 
   version:
-    "9.5":
-      version: "9.5"
-      prev_version: "9.4"
-      short: "95"
-      prev_short: "94"
-      common_image_name: "{{ spec.org }}/postgresql-95-{{ spec.prod }}"
-      rhel_image_name: "rhscl/postgresql-95-rhel7"
-      centos_image_name: "centos/postgresql-95-centos7"
-      cccp_job: "postgresql-95-centos7"
-      latest_fedora: "f25"
-
     "9.6":
       version: "9.6"
       prev_version: "9.5"
@@ -104,10 +93,6 @@ specs:
 
 matrix:
   exclude:
-    - distros:
-        - fedora-29-x86_64
-        - rhel-8-x86_64
-      version: "9.5"
     - distros:
         - rhel-8-x86_64
         - fedora-29-x86_64

--- a/src/Dockerfile.fedora
+++ b/src/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/{{ spec.latest_fedora }}/s2i-core:latest
+FROM registry.fedoraproject.org/f{{ config.os.version }}/s2i-core:latest
 
 # PostgreSQL image for OpenShift.
 # Volumes:
@@ -46,6 +46,10 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # to make sure of that.
 RUN INSTALL_PKGS="rsync tar gettext bind-utils postgresql-server postgresql-contrib nss_wrapper " && \
     INSTALL_PKGS+="findutils python2 xz" && \
+{% if spec.version not in ["9.6", "10"] %}
+    INSTALL_PKGS+=" pgaudit" && \
+{% endif %}
+    dnf -y module enable postgresql:{{ spec.version }} && \
     dnf -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all && \

--- a/src/Dockerfile.fedora
+++ b/src/Dockerfile.fedora
@@ -45,7 +45,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN INSTALL_PKGS="rsync tar gettext bind-utils postgresql-server postgresql-contrib nss_wrapper " && \
-    INSTALL_PKGS+="findutils python2 xz" && \
+    INSTALL_PKGS+="findutils xz" && \
 {% if spec.version not in ["9.6", "10"] %}
     INSTALL_PKGS+=" pgaudit" && \
 {% endif %}


### PR DESCRIPTION
move to latest stable (f31) s2i-core base image
use modules for postgresql builds
install pgaudit in postgresq 12 and later

Needs changes in https://github.com/sclorg/s2i-base-container/pull/199 synced to Fedora 31 first