### PR TITLE
[DO NOT MERGE] Demonstrate problem in running tests

### DIFF
--- a/test/run_test
+++ b/test/run_test
@@ -300,6 +300,7 @@ function try_image_invalid_combinations() {
 }
 
 function run_container_creation_tests() {
+false
   echo "  Testing image entrypoint usage"
   try_image_invalid_combinations
   try_image_invalid_combinations  -e POSTGRESQL_ADMIN_PASSWORD=admin_pass
@@ -349,6 +350,7 @@ assert_runtime_option ()
 
 
 function run_configuration_tests() {
+false
   local name=$1 ; shift
   echo "  Testing image configuration settings"
   test_config_option ${name} max_connections ${POSTGRESQL_MAX_CONNECTIONS}
@@ -522,6 +524,7 @@ function setup_replication_cluster() {
 }
 
 function run_master_restart_test() {
+false
   local DB=postgres
   local PGUSER=master
   local PASS=master
@@ -565,6 +568,7 @@ function run_master_restart_test() {
 }
 
 function run_replication_test() {
+false
   local DB=postgres
   local PGUSER=master
   local PASS=master
@@ -587,6 +591,7 @@ function run_replication_test() {
 }
 
 function run_change_password_test() {
+false
   echo "  Testing password change"
   local name="change_password"
 
@@ -650,6 +655,7 @@ $volume_options
 
 run_upgrade_test ()
 {
+false
     # Do not run on Fedora or RHEL8 until the upgrade script
     # is fixed for non-SCL use cases
     { [ "${OS}" == "fedora" ] || [ "${OS}" == "rhel8" ]; } && return 0
@@ -671,6 +677,7 @@ run_upgrade_test ()
 
 run_migration_test ()
 {
+false
     [ "${OS}" == "fedora" ] && return 0
 
     local from_version
@@ -692,6 +699,7 @@ run_migration_test ()
 }
 
 run_doc_test() {
+false
   local tmpdir=$(mktemp -d)
   local f
   echo "  Testing documentation in the container image"
@@ -740,6 +748,7 @@ ${mount_opts}
 }
 
 run_s2i_test() {
+false
   local temp_file
   echo "  Testing s2i usage"
   ct_s2i_usage "${IMAGE_NAME}" --pull-policy=never 1>/dev/null


### PR DESCRIPTION
This PR adds `false` call in the beginning of tests. Adding such a `false` call anywhere
in the test function should make the tests failed. It is not happening though.

This is caused by the change in running tests, when we wanted to run all tests by default.
However, when doing so, `set -e` setting does not work, because the -e is ignored in all
commands under if statement. This is the relevant documentation in the man page bash(1).

```
If a compound command or shell function executes in a context where -e is being ignored,
none of the commands executed within the compound command or function body will be affected
by the -e setting, even if -e is set and a command returns a failure status.

If a compound command or shell function sets -e while executing in a context where -e is
ignored, that setting will not have any effect until the compound command or the command
containing the function call completes.
```