### PR TITLE
Allow logging to /dev/stderr

### DIFF
--- a/10/root/usr/share/container-scripts/postgresql/README.md
+++ b/10/root/usr/share/container-scripts/postgresql/README.md
@@ -101,6 +101,9 @@ The following environment variables influence the PostgreSQL configuration file.
 **`POSTGRESQL_EFFECTIVE_CACHE_SIZE (default: 1/2 of memory limit or 128M)`**
        Set to an estimate of how much memory is available for disk caching by the operating system and within the database itself
 
+**`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
+       Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
+
 
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 

--- a/10/root/usr/share/container-scripts/postgresql/common.sh
+++ b/10/root/usr/share/container-scripts/postgresql/common.sh
@@ -18,6 +18,8 @@ else
     export POSTGRESQL_EFFECTIVE_CACHE_SIZE=${POSTGRESQL_EFFECTIVE_CACHE_SIZE:-$effective_cache}
 fi
 
+export POSTGRESQL_LOG_DESTINATION=${POSTGRESQL_LOG_DESTINATION:-}
+
 export POSTGRESQL_RECOVERY_FILE=$HOME/openshift-custom-recovery.conf
 export POSTGRESQL_CONFIG_FILE=$HOME/openshift-custom-postgresql.conf
 
@@ -157,6 +159,16 @@ function generate_postgresql_config() {
 
   if should_hack_data_sync_retry ; then
     echo "data_sync_retry = on" >>"${POSTGRESQL_CONFIG_FILE}"
+  fi
+
+  # For easier debugging, allow users to log to stderr (will be visible
+  # in the pod logs) using a single variable
+  # https://github.com/sclorg/postgresql-container/issues/353
+  if [ -n "${POSTGRESQL_LOG_DESTINATION:-}" ] ; then
+    echo "log_destination = 'stderr'" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "logging_collector = on" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "log_directory = '$(dirname "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "log_filename = '$(basename "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
   fi
 
   (

--- a/12/root/usr/share/container-scripts/postgresql/README.md
+++ b/12/root/usr/share/container-scripts/postgresql/README.md
@@ -101,6 +101,9 @@ The following environment variables influence the PostgreSQL configuration file.
 **`POSTGRESQL_EFFECTIVE_CACHE_SIZE (default: 1/2 of memory limit or 128M)`**
        Set to an estimate of how much memory is available for disk caching by the operating system and within the database itself
 
+**`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
+       Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
+
 
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 

--- a/12/root/usr/share/container-scripts/postgresql/common.sh
+++ b/12/root/usr/share/container-scripts/postgresql/common.sh
@@ -18,6 +18,8 @@ else
     export POSTGRESQL_EFFECTIVE_CACHE_SIZE=${POSTGRESQL_EFFECTIVE_CACHE_SIZE:-$effective_cache}
 fi
 
+export POSTGRESQL_LOG_DESTINATION=${POSTGRESQL_LOG_DESTINATION:-}
+
 export POSTGRESQL_RECOVERY_FILE=$HOME/openshift-custom-recovery.conf
 export POSTGRESQL_CONFIG_FILE=$HOME/openshift-custom-postgresql.conf
 
@@ -157,6 +159,16 @@ function generate_postgresql_config() {
 
   if should_hack_data_sync_retry ; then
     echo "data_sync_retry = on" >>"${POSTGRESQL_CONFIG_FILE}"
+  fi
+
+  # For easier debugging, allow users to log to stderr (will be visible
+  # in the pod logs) using a single variable
+  # https://github.com/sclorg/postgresql-container/issues/353
+  if [ -n "${POSTGRESQL_LOG_DESTINATION:-}" ] ; then
+    echo "log_destination = 'stderr'" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "logging_collector = on" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "log_directory = '$(dirname "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "log_filename = '$(basename "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
   fi
 
   (

--- a/13/root/usr/share/container-scripts/postgresql/README.md
+++ b/13/root/usr/share/container-scripts/postgresql/README.md
@@ -101,6 +101,9 @@ The following environment variables influence the PostgreSQL configuration file.
 **`POSTGRESQL_EFFECTIVE_CACHE_SIZE (default: 1/2 of memory limit or 128M)`**
        Set to an estimate of how much memory is available for disk caching by the operating system and within the database itself
 
+**`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
+       Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
+
 
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 

--- a/13/root/usr/share/container-scripts/postgresql/common.sh
+++ b/13/root/usr/share/container-scripts/postgresql/common.sh
@@ -18,6 +18,8 @@ else
     export POSTGRESQL_EFFECTIVE_CACHE_SIZE=${POSTGRESQL_EFFECTIVE_CACHE_SIZE:-$effective_cache}
 fi
 
+export POSTGRESQL_LOG_DESTINATION=${POSTGRESQL_LOG_DESTINATION:-}
+
 export POSTGRESQL_RECOVERY_FILE=$HOME/openshift-custom-recovery.conf
 export POSTGRESQL_CONFIG_FILE=$HOME/openshift-custom-postgresql.conf
 
@@ -157,6 +159,16 @@ function generate_postgresql_config() {
 
   if should_hack_data_sync_retry ; then
     echo "data_sync_retry = on" >>"${POSTGRESQL_CONFIG_FILE}"
+  fi
+
+  # For easier debugging, allow users to log to stderr (will be visible
+  # in the pod logs) using a single variable
+  # https://github.com/sclorg/postgresql-container/issues/353
+  if [ -n "${POSTGRESQL_LOG_DESTINATION:-}" ] ; then
+    echo "log_destination = 'stderr'" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "logging_collector = on" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "log_directory = '$(dirname "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "log_filename = '$(basename "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
   fi
 
   (

--- a/15/root/usr/share/container-scripts/postgresql/README.md
+++ b/15/root/usr/share/container-scripts/postgresql/README.md
@@ -101,6 +101,9 @@ The following environment variables influence the PostgreSQL configuration file.
 **`POSTGRESQL_EFFECTIVE_CACHE_SIZE (default: 1/2 of memory limit or 128M)`**
        Set to an estimate of how much memory is available for disk caching by the operating system and within the database itself
 
+**`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
+       Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
+
 
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 

--- a/15/root/usr/share/container-scripts/postgresql/common.sh
+++ b/15/root/usr/share/container-scripts/postgresql/common.sh
@@ -18,6 +18,8 @@ else
     export POSTGRESQL_EFFECTIVE_CACHE_SIZE=${POSTGRESQL_EFFECTIVE_CACHE_SIZE:-$effective_cache}
 fi
 
+export POSTGRESQL_LOG_DESTINATION=${POSTGRESQL_LOG_DESTINATION:-}
+
 export POSTGRESQL_RECOVERY_FILE=$HOME/openshift-custom-recovery.conf
 export POSTGRESQL_CONFIG_FILE=$HOME/openshift-custom-postgresql.conf
 
@@ -157,6 +159,16 @@ function generate_postgresql_config() {
 
   if should_hack_data_sync_retry ; then
     echo "data_sync_retry = on" >>"${POSTGRESQL_CONFIG_FILE}"
+  fi
+
+  # For easier debugging, allow users to log to stderr (will be visible
+  # in the pod logs) using a single variable
+  # https://github.com/sclorg/postgresql-container/issues/353
+  if [ -n "${POSTGRESQL_LOG_DESTINATION:-}" ] ; then
+    echo "log_destination = 'stderr'" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "logging_collector = on" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "log_directory = '$(dirname "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "log_filename = '$(basename "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
   fi
 
   (

--- a/src/root/usr/share/container-scripts/postgresql/README.md
+++ b/src/root/usr/share/container-scripts/postgresql/README.md
@@ -101,6 +101,9 @@ The following environment variables influence the PostgreSQL configuration file.
 **`POSTGRESQL_EFFECTIVE_CACHE_SIZE (default: 1/2 of memory limit or 128M)`**
        Set to an estimate of how much memory is available for disk caching by the operating system and within the database itself
 
+**`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
+       Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
+
 
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 

--- a/test/run_test
+++ b/test/run_test
@@ -29,6 +29,7 @@ run_s2i_enable_ssl_test
 run_upgrade_test
 run_migration_test
 run_pgaudit_test
+run_logging_test
 "
 
 test $# -eq 1 -a "${1-}" == --list && echo "$TEST_LIST" && exit 0
@@ -936,6 +937,42 @@ EOSQL" || ret=3
     echo "  Success!"
   fi
   return $ret
+}
+
+run_logging_test()
+{
+  local data_dir name=pg-test-logging
+
+  # create a dir for data
+  create_volume_dir
+  data_dir="${volume_dir}"
+
+  DOCKER_ARGS="
+-e POSTGRESQL_ADMIN_PASSWORD=password
+-e POSTGRESQL_LOG_DESTINATION=/dev/stderr
+-v ${data_dir}:/var/lib/pgsql/data:Z
+  " create_container "$name"
+
+  assert_runtime_option "$name" log_destination logging_collector log_directory log_filename
+  wait_ready "$name"
+
+  # enable the pgaudit extension
+  echo 'psql -U nonexistent' | docker exec -i $(get_cid "$name") bash || :
+
+  # give server some time for write all audit messages
+  sleep 1
+
+  # check whether we have a correct output in the container log
+  if ! docker logs $(get_cid "$name") 2>&1 | grep -q 'FATAL:  role "nonexistent" does not exist' ; then
+    echo "ERROR: the container log does not include expected error message"
+    return 1
+  fi
+
+  # the traditional log file should not exist
+  while f in "${data_dir}"/userdata/log/postgresql-*.log ] ; do
+    echo "ERROR: the traditional log file $f should not exist"
+    return 1
+  done
 }
 
 # configuration defaults

--- a/test/run_test
+++ b/test/run_test
@@ -956,23 +956,29 @@ run_logging_test()
   assert_runtime_option "$name" log_destination logging_collector log_directory log_filename
   wait_ready "$name"
 
-  # enable the pgaudit extension
+  # try loggin in as a user that does not exist to trigger an error log message
   echo 'psql -U nonexistent' | docker exec -i $(get_cid "$name") bash || :
 
   # give server some time for write all audit messages
   sleep 1
 
   # check whether we have a correct output in the container log
-  if ! docker logs $(get_cid "$name") 2>&1 | grep -q 'FATAL:  role "nonexistent" does not exist' ; then
+  if docker logs $(get_cid "$name") 2>&1 | grep -q 'FATAL:  role "nonexistent" does not exist' ; then
+    echo "    PASS: the container log does include expected error message"
+  else
     echo "ERROR: the container log does not include expected error message"
     return 1
   fi
 
   # the traditional log file should not exist
-  while f in "${data_dir}"/userdata/log/postgresql-*.log ] ; do
-    echo "ERROR: the traditional log file $f should not exist"
-    return 1
+  for f in "${data_dir}"/userdata/log/postgresql-*.log ; do
+    if test -f "$f" ; then
+      echo "ERROR: the traditional log file $f should not exist"
+      return 1
+    fi
   done
+  echo "    PASS: the traditional log file under ${data_dir}/userdata/log/postgresql-*.log does not exist"
+  echo "  Success!"
 }
 
 # configuration defaults


### PR DESCRIPTION
For easier debugging, it should be pretty easy to switch daemon to log into the /dev/stderr.
This adds such a feature by setting POSTGRESQL_LOG_DESTINATION environment variable to /dev/stderr.

This should address #353.