### PR TITLE
Turn the data_sync_retry to on for all versions

### DIFF
--- a/src/root/usr/share/container-scripts/postgresql/common.sh
+++ b/src/root/usr/share/container-scripts/postgresql/common.sh
@@ -119,7 +119,7 @@ function generate_postgresql_config() {
         >> "${POSTGRESQL_CONFIG_FILE}"
   fi
 
-  if [ "$POSTGRESQL_VERSION" -ge 12 ] && [ "$(uname -p)" != 'x86_64' ] && [[ "$(. /etc/os-release ; echo $VERSION_ID)" =~ 7.* ]] ; then
+  if [ "$(uname -p)" != 'x86_64' ] && [[ "$(. /etc/os-release ; echo $VERSION_ID)" =~ 7.* ]] ; then
     # On non-intel arches, data_sync_retry = off does not work
     # Upstream discussion: https://www.postgresql.org/message-id/CA+mCpegfOUph2U4ZADtQT16dfbkjjYNJL1bSTWErsazaFjQW9A@mail.gmail.com
     # Upstream changes that caused this issue:


### PR DESCRIPTION
Because the change was done for all supported versions in upstream:
https://www.postgresql.org/about/news/1920/

Previously work-arounded for PostgreSQL v12 only:
https://github.com/sclorg/postgresql-container/pull/354

We hit this with the 10.12 version
Resolves: #1819122