### PR TITLE
[WIP] Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -14,11 +14,11 @@ source "$THISDIR"/pg-test-lib.sh
 source "$THISDIR"/test-lib-openshift.sh
 source "$THISDIR"/test-lib-postgresql.sh
 
-set -exo nounset
+set -eo nounset
 
-test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
-test -n "${VERSION-}" || false 'make sure $VERSION is defined'
-test -n "${OS-}" || false 'make sure $OS is defined'
+trap ct_os_cleanup EXIT SIGINT
+
+ct_os_check_compulsory_vars
 
 # Populate template variables if not set already
 if [ -z "${EPHEMERAL_TEMPLATES:-}" ]; then
@@ -428,6 +428,7 @@ run_persistent_tests "$IMAGE_NAME"
 test_postgresql_configmap_start "$IMAGE_NAME"
 
 # test with the just built image and an integrated template
+echo "Running test_postgresql_integration with ${IMAGE_NAME}"
 test_postgresql_integration "${IMAGE_NAME}" "${VERSION}" postgresql
 
 # test with a released image and an integrated template
@@ -440,15 +441,22 @@ else
   fail_not_released=false
 fi
 
-export CT_SKIP_UPLOAD_IMAGE=true
 # Try pulling the image first to see if it is accessible
 if docker pull "${PUBLIC_IMAGE_NAME}"; then
-  test_postgresql_integration postgresql "${VERSION}" "${PUBLIC_IMAGE_NAME}"
+  echo "Running test_postgresql_integration with ${PUBLIC_IMAGE_NAME}"
+  test_postgresql_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" postgresql
 else
   echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
   ! $fail_not_released || false "ERROR: Failed to pull image"
 fi
 
+# Check the imagestream
+echo "Running test_mariadb_imagestream"
+test_postgresql_imagestream
+
 OS_TESTSUITE_RESULT=0
 
 ct_os_cluster_down
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
+

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -429,25 +429,19 @@ test_postgresql_configmap_start "$IMAGE_NAME"
 
 # test with the just built image and an integrated template
 echo "Running test_postgresql_integration with ${IMAGE_NAME}"
-test_postgresql_integration "${IMAGE_NAME}" "${VERSION}" postgresql
+test_postgresql_integration "${IMAGE_NAME}"
 
 # test with a released image and an integrated template
-# ignore possible failure of this test for centos images
-fail_not_released=true
-if [ "${OS}" == "rhel7" ] ; then
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.redhat.io/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
-else
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-}centos/${BASE_IMAGE_NAME}-${VERSION//./}-centos7}
-  fail_not_released=false
-fi
+PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-$(ct_get_public_image_name "${OS}" "${BASE_IMAGE_NAME}" "${VERSION}")}
 
 # Try pulling the image first to see if it is accessible
 if docker pull "${PUBLIC_IMAGE_NAME}"; then
   echo "Running test_postgresql_integration with ${PUBLIC_IMAGE_NAME}"
-  test_postgresql_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" postgresql
+  test_postgresql_integration "${PUBLIC_IMAGE_NAME}"
 else
   echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
-  ! $fail_not_released || false "ERROR: Failed to pull image"
+  # ignore possible failure of this test for centos images
+  [ "${OS}" == "rhel7" ] && false "ERROR: Failed to pull image"
 fi
 
 # Check the imagestream

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -14,7 +14,7 @@ source "$THISDIR"/pg-test-lib.sh
 source "$THISDIR"/test-lib-openshift.sh
 source "$THISDIR"/test-lib-postgresql.sh
 
-set -eo nounset
+set -exo nounset
 
 trap ct_os_cleanup EXIT SIGINT
 

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -25,7 +25,7 @@ export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
 # Check the template
-test_postgresql_integration "${IMAGE_NAME}" ${VERSION} postgresql
+test_postgresql_integration "${IMAGE_NAME}"
 
 # Check the imagestream
 test_postgresql_imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,13 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_postgresql_integration postgresql ${VERSION} "${IMAGE_NAME}"
+# Check the template
+test_postgresql_integration "${IMAGE_NAME}" ${VERSION} postgresql
+
+# Check the imagestream
+test_postgresql_imagestream
 
 OS_TESTSUITE_RESULT=0
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/test-lib-postgresql.sh
+++ b/test/test-lib-postgresql.sh
@@ -13,9 +13,7 @@ source ${THISDIR}/test-lib-openshift.sh
 
 function test_postgresql_integration() {
   local image_name=$1
-  local VERSION=$2
-  local service_name=$3
-  local image_tagged="${service_name}:${VERSION}"
+  local service_name=postgresql
   ct_os_template_exists postgresql-ephemeral && t=postgresql-ephemeral || t=postgresql-persistent
   ct_os_test_template_app_func "${image_name}" \
                                "${t}" \

--- a/test/test-lib-postgresql.sh
+++ b/test/test-lib-postgresql.sh
@@ -14,18 +14,28 @@ source ${THISDIR}/test-lib-openshift.sh
 function test_postgresql_integration() {
   local image_name=$1
   local VERSION=$2
-  local import_image=$3
-  local service_name=${import_image##*/}
+  local service_name=$3
+  local image_tagged="${service_name}:${VERSION}"
   ct_os_template_exists postgresql-ephemeral && t=postgresql-ephemeral || t=postgresql-persistent
   ct_os_test_template_app_func "${image_name}" \
                                "${t}" \
                                "${service_name}" \
-                               "ct_os_check_cmd_internal '${import_image}' '${service_name}' 'PGPASSWORD=testp pg_isready -t 15 -h <IP> -U testu -d testdb' 'accepting connections' 120" \
+                               "ct_os_check_cmd_internal '<SAME_IMAGE>' '${service_name}-testing' 'PGPASSWORD=testp pg_isready -t 15 -h <IP> -U testu -d testdb' 'accepting connections' 120" \
                                "-p POSTGRESQL_VERSION=${VERSION} \
                                 -p DATABASE_SERVICE_NAME="${service_name}-testing" \
                                 -p POSTGRESQL_USER=testu \
                                 -p POSTGRESQL_PASSWORD=testp \
-                                -p POSTGRESQL_DATABASE=testdb" "" "${import_image}"
+                                -p POSTGRESQL_DATABASE=testdb"
+}
+
+# Check the imagestream
+function test_postgresql_imagestream() {
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/postgresql-${OS}.json" "${THISDIR}/../examples/postgresql-ephemeral-template.json" postgresql "-p POSTGRESQL_VERSION=${VERSION}"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster