### PR TITLE
Add centos8 support for the dist-gen configs

### DIFF
--- a/manifest.sh
+++ b/manifest.sh
@@ -29,6 +29,9 @@ DISTGEN_MULTI_RULES="
     dest=Dockerfile;
 
     src=src/Dockerfile
+    dest=Dockerfile.centos8;
+
+    src=src/Dockerfile
     dest=Dockerfile.rhel7;
 
     src=src/Dockerfile

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -2,7 +2,7 @@ version: 1
 
 specs:
   distroinfo:
-    centos:
+    centos7:
       distros:
         - centos-7-x86_64
       s2i_base: centos/s2i-core-centos7
@@ -18,6 +18,20 @@ specs:
       staging_repo_setup: >-4
               yum-config-manager --add-repo https://cbs.centos.org/repos/sclo7-rh-postgresql96-rh-candidate/x86_64/os/ && \
               echo gpgcheck=0 >> /etc/yum.repos.d/cbs.centos.org_repos_sclo7-rh-postgresql96-rh-candidate_x86_64_os_.repo && \
+    centos8:
+      distros:
+        - centos-8-x86_64
+      s2i_base: centos/s2i-core-centos8
+      org: "centos"
+      prod: "centos8"
+      openshift_tags: "database,postgresql,postgresql{{ spec.short }},postgresql-{{ spec.short }}"
+      redhat_component: "postgresql-{{ spec.short }}-container"
+      img_name: "{{ spec.org }}/postgresql-{{ spec.short }}-{{ spec.prod }}"
+      pkgs: "postgresql-server postgresql-contrib"
+      environment_setup: >-4
+          yum -y module enable postgresql:{{ spec.version }} && \
+      post_install: >-4
+          yum -y reinstall tzdata && \
     rhel7:
        distros:
          - rhel-7-x86_64
@@ -110,6 +124,7 @@ matrix:
         - rhel-7-x86_64
         - rhel-8-x86_64
         - centos-7-x86_64
+        - centos-8-x86_64
       version: "11"
     - distros:
         - rhel-8-x86_64

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -71,7 +71,11 @@ RUN {{ spec.environment_setup }}
 {% endif %}
     INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper {{ spec.pkgs }}" && \
 {% if spec.version in ["12"] %}
+{% if config.os.version == 7 %}
     INSTALL_PKGS="$INSTALL_PKGS rh-postgresql{{ spec.short }}-pgaudit" && \
+{% else %}
+    INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
+{% endif %}
 {% endif %}
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
To work properly, https://github.com/devexp-db/distgen/pull/106 must be merged first nad new dist-gen released + updated