### PR TITLE
Move test latest_imagestreams into openshift tests

### DIFF
--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -118,14 +118,13 @@ function check_postgresql_os_service_connection() {
 function test_postgresql_pure_image() {
   local image_name=$1
   local image_name_no_namespace=${image_name##*/}
-  local service_name=${image_name_no_namespace}
+  local service_name="${image_name_no_namespace%%:*}-testing"
 
   ct_os_new_project
-  ct_os_upload_image "${image_name}"
   # Create a specific imagestream tag for the image so that oc cannot use anything else
-  ct_os_upload_image "${image_name}" "$image_name_no_namespace:testing"
+  ct_os_upload_image "${image_name}" "$image_name_no_namespace"
 
-  ct_os_deploy_pure_image "$image_name_no_namespace:testing" \
+  ct_os_deploy_pure_image "$image_name_no_namespace" \
                           --name "${service_name}" \
                           --env POSTGRESQL_ADMIN_PASSWORD=test
 
@@ -139,7 +138,7 @@ function test_postgresql_template() {
   local image_name=$1; shift
   local template=$1
   local image_name_no_namespace=${image_name##*/}
-  local service_name=${image_name_no_namespace}
+  local service_name="${image_name_no_namespace%%:*}-testing"
 
   ct_os_new_project
   ct_os_upload_image "${image_name}" "postgresql:$VERSION"
@@ -161,8 +160,8 @@ function test_postgresql_template() {
 function test_postgresql_update() {
   local image_name=$1; shift
   local template=$1
-  local image_name_no_registry=${image_name#*/}
-  local service_name=${image_name_no_registry#*/}
+  local image_name_no_registry=${image_name##*/}
+  local service_name="${image_name_no_registry%%:*}-testing"
   local user="testu" pass="testp" db="testdb"
   local registry="" old_image="" pod_ip=""
   local version released=:
@@ -219,8 +218,8 @@ function test_postgresql_update() {
 function test_postgresql_replication() {
   local image_name=$1
   local image_name_no_namespace=${image_name##*/}
-  local master_service_name=${image_name_no_namespace}-master
-  local slave_service_name=${image_name_no_namespace}-slave
+  local master_service_name="${image_name_no_namespace%%:*}-master"
+  local slave_service_name="${image_name_no_namespace%%:*}-slave"
   local istag="postgresql:$VERSION"
   local user="testu" pass="testp" db="testdb"
   local master_name="" master_ip="" slave_name="" slave_ip=""
@@ -289,7 +288,7 @@ function test_postgresql_persistent_redeploy() {
   local image_name=$1; shift
   local template=$1
   local image_name_no_namespace=${image_name##*/}
-  local service_name=$image_name_no_namespace
+  local service_name="${image_name_no_namespace%%:*}-testing"
   local user="testu" pass="testp" db="testdb"
   local registry="" old_image="" pod_ip=""
 
@@ -327,7 +326,7 @@ function test_postgresql_ephemeral_redeploy() {
   local image_name=$1; shift
   local template=$1
   local image_name_no_namespace=${image_name##*/}
-  local service_name=$image_name_no_namespace
+  local service_name="${image_name_no_namespace%%:*}-testing"
   local user="testu" pass="testp" db="testdb"
   local registry="" old_image="" pod_ip=""
 
@@ -365,7 +364,7 @@ function test_postgresql_configmap_start() {
   local image_name=$1; shift
   local template="$TEMPLATES/postgresql-ephemeral-template.json"
   local image_name_no_namespace=${image_name##*/}
-  local service_name=$image_name_no_namespace
+  local service_name="${image_name_no_namespace%%:*}-testing"
   local user="testu" pass="testp" db="testdb"
   local registry="" old_image="" pod_ip="" tmpdir=""
   local test_string=""

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -448,6 +448,19 @@ fi
 echo "Running test_mariadb_imagestream"
 test_postgresql_imagestream
 
+function run_latest_imagestreams_test() {
+  local result=1
+  # Switch to root directory of a container
+  echo "Testing the latest version in imagestreams"
+  pushd "${test_dir}/.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  return $result
+}
+
+run_latest_imagestreams_test
+
 OS_TESTSUITE_RESULT=0
 
 ct_os_cluster_down

--- a/test/run_test
+++ b/test/run_test
@@ -29,7 +29,6 @@ run_s2i_enable_ssl_test
 run_upgrade_test
 run_migration_test
 run_pgaudit_test
-run_latest_imagestreams_test
 "
 
 test $# -eq 1 -a "${1-}" == --list && echo "$TEST_LIST" && exit 0
@@ -897,17 +896,6 @@ EOSQL"
 
   grep -E 'AUDIT: SESSION,.*,.*,DDL,CREATE DATABASE,,,CREATE DATABASE pgaudittest' "${data_dir}"/userdata/log/postgresql-*.log
   grep -E 'AUDIT: SESSION,.*,.*,READ,SELECT,,,SELECT' "${data_dir}"/userdata/log/postgresql-*.log
-}
-
-function run_latest_imagestreams_test() {
-  local result=1
-  # Switch to root directory of a container
-  echo "Testing the latest version in imagestreams"
-  pushd "${test_dir}/.." >/dev/null || return 1
-  ct_check_latest_imagestreams
-  result=$?
-  popd >/dev/null || return 1
-  return $result
 }
 
 function run_all_tests() {

--- a/test/test-lib-postgresql.sh
+++ b/test/test-lib-postgresql.sh
@@ -33,7 +33,7 @@ function test_postgresql_imagestream() {
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
 
-  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/postgresql-${OS%[0-9]*}.json" "${THISDIR}/../examples/postgresql-ephemeral-template.json" postgresql "-p POSTGRESQL_VERSION=${VERSION}"
+  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/postgresql-${OS%%[0-9]*}.json" "${THISDIR}/../examples/postgresql-ephemeral-template.json" postgresql "-p POSTGRESQL_VERSION=${VERSION}"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
Move test latest_imagestreams into openshift tests.
Update container-common-scripts into the latest.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>