### PR TITLE
Support Quay.io registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 PostgreSQL container images
 ========================
 
+PostgreSQL 10 status:[![Docker Repository on Quay](https://quay.io/repository/centos7/postgresql-10-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/postgresql-10-centos7), PostgreSQL 12 status:[![Docker Repository on Quay](https://quay.io/repository/centos7/postgresql-12-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/postgresql-12-centos7)
+
 This repository contains Dockerfiles for PostgreSQL images for OpenShift.
 Users can choose between RHEL, Fedora and CentOS based images.
 

--- a/imagestreams/postgresql-centos.json
+++ b/imagestreams/postgresql-centos.json
@@ -56,7 +56,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/postgresql-12-centos7:latest"
+          "name": "quay.io/centos7/postgresql-12-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -74,7 +74,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/postgresql-12-centos7:latest"
+          "name": "quay.io/centos7/postgresql-12-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -110,7 +110,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/postgresql-10-centos7:latest"
+          "name": "quay.io/centos7/postgresql-10-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -128,7 +128,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/postgresql-10-centos7:latest"
+          "name": "quay.io/centos7/postgresql-10-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -5,13 +5,13 @@ specs:
     centos:
       distros:
         - centos-7-x86_64
-      s2i_base: centos/s2i-core-centos7
-      org: "centos"
+      s2i_base: quay.io/centos7/s2i-core-centos7
+      org: "centos7"
       prod: "centos7"
       openshift_tags: "database,postgresql,postgresql{{ spec.short }},rh-postgresql{{ spec.short }}"
       redhat_component: "rh-postgresql{{ spec.short }}-container"
       enabled_collection: "rh-postgresql{{ spec.short }}"
-      img_name: "{{ spec.org }}/postgresql-{{ spec.short }}-{{ spec.prod }}"
+      img_name: "quay.io/{{ spec.org }}/postgresql-{{ spec.short }}-{{ spec.prod }}"
       pkgs: "rh-postgresql{{ spec.short }} rh-postgresql{{ spec.short }}-postgresql-contrib rh-postgresql{{ spec.short }}-syspaths rh-postgresql{{ spec.prev_short }}-postgresql-server"
       repo_enable_reason: ""
       environment_setup: yum install -y centos-release-scl-rh && \

--- a/src/root/usr/share/container-scripts/postgresql/README.md
+++ b/src/root/usr/share/container-scripts/postgresql/README.md
@@ -4,7 +4,7 @@ PostgreSQL {{ spec.version }} SQL Database Server container image
 This container image includes PostgreSQL {{ spec.version }} SQL database server for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -123,7 +123,7 @@ $ podman run <...> -v /your/data/dir:/var/lib/pgsql/data:Z <...>
 
 
 Data migration
-----------------------
+--------------
 
 PostgreSQL container supports migration of data from remote PostgreSQL server.
 You can run it like:
@@ -173,7 +173,7 @@ clusters is not encrypted by default, it is up to user to configure SSL on
 remote cluster or ensure security via different means.
 
 PostgreSQL auto-tuning
---------------------
+----------------------
 
 When the PostgreSQL image is run with the `--memory` parameter set and if there
 are no values provided for `POSTGRESQL_SHARED_BUFFERS` and


### PR DESCRIPTION
This pull request supports building image on Quay.io instead of
Docker.io.
This is caused by introducing Docker.io rate limits.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>