### PR TITLE
WIP: Add 2 helpers for adding extension more easily

### DIFF
--- a/src/root/usr/bin/create_extension
+++ b/src/root/usr/bin/create_extension
@@ -1,0 +1,5 @@
+#!/bin/sh
+EXT=$1
+mkdir -p ~/postgresql-start
+echo "psql -c 'CREATE EXTENSION IF NOT EXISTS ${EXT};' \$POSTGRESQL_DATABASE" > ~/postgresql-start/enable_${EXT}.sh
+

--- a/src/root/usr/bin/load_pg_library
+++ b/src/root/usr/bin/load_pg_library
@@ -1,0 +1,4 @@
+#!/bin/sh
+LIB=$1
+mkdir -p ~/postgresql-cfg
+echo "shared_preload_libraries='${LIB}'" > ~/postgresql-cfg/${LIB}.conf


### PR DESCRIPTION
This PR should go along #394, that as I as a basis to get postgis in postgresql.

I used that dockerfile:
```
FROM registry.fedoraproject.org/f33/postgresql
USER 0
RUN mkdir -p postgresql-cfg && echo "shared_preload_libraries='postgis-3'" > postgresql-cfg/postgis.conf
RUN mkdir -p postgresql-init && echo -en 'echo "CREATE EXTENSION IF NOT EXISTS postgis;" | psql' > postgresql-init/enable_postgis.sh
RUN dnf install --setopt=install_weak_deps=False --best -y postgis && dnf clean all
USER 26
```

However, with the addition of the 2 helpers, I think this could be simplified to be:
```        
FROM postgres-fedora
USER 0
RUN dnf install --setopt=install_weak_deps=False --best -y postgis && dnf clean all
RUN load_pg_library postgis-3 
RUN create_extension postgis 
USER 26
```

This permit to hide implementation details, and avoid cut and paste (since postgis provides 4 extensions), and stupid errors (i took me a while to get a working container).

I marked the PR as WIP since there is no doc as I do not know where you would like to add it, and there is also no test (but I guess this can be done with pgaudit).