### PR TITLE
Add support for extensions loading and creation.

### DIFF
--- a/10/root/usr/bin/run-postgresql
+++ b/10/root/usr/bin/run-postgresql
@@ -47,6 +47,7 @@ if $PG_INITIALIZED ; then
     create_users
 fi
 
+create_extensions
 process_extending_files \
     "${APP_DATA}/src/postgresql-start" \
     "${CONTAINER_SCRIPTS_PATH}/start"

--- a/10/root/usr/share/container-scripts/postgresql/README.md
+++ b/10/root/usr/share/container-scripts/postgresql/README.md
@@ -74,6 +74,15 @@ Set to an estimate of how much memory is available for disk caching by the opera
 **`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
  Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
 
+The following environment variables deal with extensions. They are all optional, and if not set, no extensions will be enabled.
+
+**`POSTGRESQL_LIBRARIES`**
+       A comma-separated list of libraries that Postgres will preload using shared_preload_libraries.
+
+**`POSTGRESQL_EXTENSIONS`**
+       A space-separated list of extensions to create when the server start. Once created, the extensions will stay even if the variable is cleared.
+
+
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 
 **`/var/lib/pgsql/data`**  

--- a/10/root/usr/share/container-scripts/postgresql/common.sh
+++ b/10/root/usr/share/container-scripts/postgresql/common.sh
@@ -144,6 +144,13 @@ function should_hack_data_sync_retry() {
   return 1
 }
 
+function generate_postgresql_libraries_config() {
+  if [ -v POSTGRESQL_LIBRARIES ]; then
+    echo "shared_preload_libraries='${POSTGRESQL_LIBRARIES}'" >> "${POSTGRESQL_CONFIG_FILE}"
+  fi
+}
+
+
 # New config is generated every time a container is created. It only contains
 # additional custom settings and is included from $PGDATA/postgresql.conf.
 function generate_postgresql_config() {
@@ -171,6 +178,7 @@ function generate_postgresql_config() {
     echo "log_filename = '$(basename "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
   fi
 
+  generate_postgresql_libraries_config
   (
   shopt -s nullglob
   for conf in "${APP_DATA}"/src/postgresql-cfg/*.conf; do
@@ -515,4 +523,13 @@ process_extending_files()
       fi
     done
   done <<<"$(get_matched_files '*.sh' "$@" | sort -u)"
+}
+
+create_extensions()
+{
+  if [ -v POSTGRESQL_EXTENSIONS ]; then
+    for EXT in $POSTGRESQL_EXTENSIONS; do
+      psql -c "CREATE EXTENSION IF NOT EXISTS ${EXT};"
+    done
+  fi
 }

--- a/12/root/usr/bin/run-postgresql
+++ b/12/root/usr/bin/run-postgresql
@@ -47,6 +47,7 @@ if $PG_INITIALIZED ; then
     create_users
 fi
 
+create_extensions
 process_extending_files \
     "${APP_DATA}/src/postgresql-start" \
     "${CONTAINER_SCRIPTS_PATH}/start"

--- a/12/root/usr/share/container-scripts/postgresql/README.md
+++ b/12/root/usr/share/container-scripts/postgresql/README.md
@@ -74,6 +74,15 @@ Set to an estimate of how much memory is available for disk caching by the opera
 **`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
  Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
 
+The following environment variables deal with extensions. They are all optional, and if not set, no extensions will be enabled.
+
+**`POSTGRESQL_LIBRARIES`**
+       A comma-separated list of libraries that Postgres will preload using shared_preload_libraries.
+
+**`POSTGRESQL_EXTENSIONS`**
+       A space-separated list of extensions to create when the server start. Once created, the extensions will stay even if the variable is cleared.
+
+
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 
 **`/var/lib/pgsql/data`**  

--- a/12/root/usr/share/container-scripts/postgresql/common.sh
+++ b/12/root/usr/share/container-scripts/postgresql/common.sh
@@ -144,6 +144,13 @@ function should_hack_data_sync_retry() {
   return 1
 }
 
+function generate_postgresql_libraries_config() {
+  if [ -v POSTGRESQL_LIBRARIES ]; then
+    echo "shared_preload_libraries='${POSTGRESQL_LIBRARIES}'" >> "${POSTGRESQL_CONFIG_FILE}"
+  fi
+}
+
+
 # New config is generated every time a container is created. It only contains
 # additional custom settings and is included from $PGDATA/postgresql.conf.
 function generate_postgresql_config() {
@@ -171,6 +178,7 @@ function generate_postgresql_config() {
     echo "log_filename = '$(basename "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
   fi
 
+  generate_postgresql_libraries_config
   (
   shopt -s nullglob
   for conf in "${APP_DATA}"/src/postgresql-cfg/*.conf; do
@@ -515,4 +523,13 @@ process_extending_files()
       fi
     done
   done <<<"$(get_matched_files '*.sh' "$@" | sort -u)"
+}
+
+create_extensions()
+{
+  if [ -v POSTGRESQL_EXTENSIONS ]; then
+    for EXT in $POSTGRESQL_EXTENSIONS; do
+      psql -c "CREATE EXTENSION IF NOT EXISTS ${EXT};"
+    done
+  fi
 }

--- a/13/root/usr/bin/run-postgresql
+++ b/13/root/usr/bin/run-postgresql
@@ -47,6 +47,7 @@ if $PG_INITIALIZED ; then
     create_users
 fi
 
+create_extensions
 process_extending_files \
     "${APP_DATA}/src/postgresql-start" \
     "${CONTAINER_SCRIPTS_PATH}/start"

--- a/13/root/usr/share/container-scripts/postgresql/README.md
+++ b/13/root/usr/share/container-scripts/postgresql/README.md
@@ -74,6 +74,15 @@ Set to an estimate of how much memory is available for disk caching by the opera
 **`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
  Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
 
+The following environment variables deal with extensions. They are all optional, and if not set, no extensions will be enabled.
+
+**`POSTGRESQL_LIBRARIES`**
+       A comma-separated list of libraries that Postgres will preload using shared_preload_libraries.
+
+**`POSTGRESQL_EXTENSIONS`**
+       A space-separated list of extensions to create when the server start. Once created, the extensions will stay even if the variable is cleared.
+
+
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 
 **`/var/lib/pgsql/data`**  

--- a/13/root/usr/share/container-scripts/postgresql/common.sh
+++ b/13/root/usr/share/container-scripts/postgresql/common.sh
@@ -144,6 +144,13 @@ function should_hack_data_sync_retry() {
   return 1
 }
 
+function generate_postgresql_libraries_config() {
+  if [ -v POSTGRESQL_LIBRARIES ]; then
+    echo "shared_preload_libraries='${POSTGRESQL_LIBRARIES}'" >> "${POSTGRESQL_CONFIG_FILE}"
+  fi
+}
+
+
 # New config is generated every time a container is created. It only contains
 # additional custom settings and is included from $PGDATA/postgresql.conf.
 function generate_postgresql_config() {
@@ -171,6 +178,7 @@ function generate_postgresql_config() {
     echo "log_filename = '$(basename "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
   fi
 
+  generate_postgresql_libraries_config
   (
   shopt -s nullglob
   for conf in "${APP_DATA}"/src/postgresql-cfg/*.conf; do
@@ -515,4 +523,13 @@ process_extending_files()
       fi
     done
   done <<<"$(get_matched_files '*.sh' "$@" | sort -u)"
+}
+
+create_extensions()
+{
+  if [ -v POSTGRESQL_EXTENSIONS ]; then
+    for EXT in $POSTGRESQL_EXTENSIONS; do
+      psql -c "CREATE EXTENSION IF NOT EXISTS ${EXT};"
+    done
+  fi
 }

--- a/14/root/usr/bin/run-postgresql
+++ b/14/root/usr/bin/run-postgresql
@@ -47,6 +47,7 @@ if $PG_INITIALIZED ; then
     create_users
 fi
 
+create_extensions
 process_extending_files \
     "${APP_DATA}/src/postgresql-start" \
     "${CONTAINER_SCRIPTS_PATH}/start"

--- a/14/root/usr/share/container-scripts/postgresql/README.md
+++ b/14/root/usr/share/container-scripts/postgresql/README.md
@@ -74,6 +74,15 @@ Set to an estimate of how much memory is available for disk caching by the opera
 **`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
  Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
 
+The following environment variables deal with extensions. They are all optional, and if not set, no extensions will be enabled.
+
+**`POSTGRESQL_LIBRARIES`**
+       A comma-separated list of libraries that Postgres will preload using shared_preload_libraries.
+
+**`POSTGRESQL_EXTENSIONS`**
+       A space-separated list of extensions to create when the server start. Once created, the extensions will stay even if the variable is cleared.
+
+
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 
 **`/var/lib/pgsql/data`**  

--- a/14/root/usr/share/container-scripts/postgresql/common.sh
+++ b/14/root/usr/share/container-scripts/postgresql/common.sh
@@ -144,6 +144,13 @@ function should_hack_data_sync_retry() {
   return 1
 }
 
+function generate_postgresql_libraries_config() {
+  if [ -v POSTGRESQL_LIBRARIES ]; then
+    echo "shared_preload_libraries='${POSTGRESQL_LIBRARIES}'" >> "${POSTGRESQL_CONFIG_FILE}"
+  fi
+}
+
+
 # New config is generated every time a container is created. It only contains
 # additional custom settings and is included from $PGDATA/postgresql.conf.
 function generate_postgresql_config() {
@@ -171,6 +178,7 @@ function generate_postgresql_config() {
     echo "log_filename = '$(basename "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
   fi
 
+  generate_postgresql_libraries_config
   (
   shopt -s nullglob
   for conf in "${APP_DATA}"/src/postgresql-cfg/*.conf; do
@@ -515,4 +523,13 @@ process_extending_files()
       fi
     done
   done <<<"$(get_matched_files '*.sh' "$@" | sort -u)"
+}
+
+create_extensions()
+{
+  if [ -v POSTGRESQL_EXTENSIONS ]; then
+    for EXT in $POSTGRESQL_EXTENSIONS; do
+      psql -c "CREATE EXTENSION IF NOT EXISTS ${EXT};"
+    done
+  fi
 }

--- a/15/root/usr/bin/run-postgresql
+++ b/15/root/usr/bin/run-postgresql
@@ -47,6 +47,7 @@ if $PG_INITIALIZED ; then
     create_users
 fi
 
+create_extensions
 process_extending_files \
     "${APP_DATA}/src/postgresql-start" \
     "${CONTAINER_SCRIPTS_PATH}/start"

--- a/15/root/usr/share/container-scripts/postgresql/README.md
+++ b/15/root/usr/share/container-scripts/postgresql/README.md
@@ -74,6 +74,15 @@ Set to an estimate of how much memory is available for disk caching by the opera
 **`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
  Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
 
+The following environment variables deal with extensions. They are all optional, and if not set, no extensions will be enabled.
+
+**`POSTGRESQL_LIBRARIES`**
+       A comma-separated list of libraries that Postgres will preload using shared_preload_libraries.
+
+**`POSTGRESQL_EXTENSIONS`**
+       A space-separated list of extensions to create when the server start. Once created, the extensions will stay even if the variable is cleared.
+
+
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 
 **`/var/lib/pgsql/data`**  

--- a/15/root/usr/share/container-scripts/postgresql/common.sh
+++ b/15/root/usr/share/container-scripts/postgresql/common.sh
@@ -144,6 +144,13 @@ function should_hack_data_sync_retry() {
   return 1
 }
 
+function generate_postgresql_libraries_config() {
+  if [ -v POSTGRESQL_LIBRARIES ]; then
+    echo "shared_preload_libraries='${POSTGRESQL_LIBRARIES}'" >> "${POSTGRESQL_CONFIG_FILE}"
+  fi
+}
+
+
 # New config is generated every time a container is created. It only contains
 # additional custom settings and is included from $PGDATA/postgresql.conf.
 function generate_postgresql_config() {
@@ -171,6 +178,7 @@ function generate_postgresql_config() {
     echo "log_filename = '$(basename "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
   fi
 
+  generate_postgresql_libraries_config
   (
   shopt -s nullglob
   for conf in "${APP_DATA}"/src/postgresql-cfg/*.conf; do
@@ -515,4 +523,13 @@ process_extending_files()
       fi
     done
   done <<<"$(get_matched_files '*.sh' "$@" | sort -u)"
+}
+
+create_extensions()
+{
+  if [ -v POSTGRESQL_EXTENSIONS ]; then
+    for EXT in $POSTGRESQL_EXTENSIONS; do
+      psql -c "CREATE EXTENSION IF NOT EXISTS ${EXT};"
+    done
+  fi
 }

--- a/16/root/usr/bin/run-postgresql
+++ b/16/root/usr/bin/run-postgresql
@@ -47,6 +47,7 @@ if $PG_INITIALIZED ; then
     create_users
 fi
 
+create_extensions
 process_extending_files \
     "${APP_DATA}/src/postgresql-start" \
     "${CONTAINER_SCRIPTS_PATH}/start"

--- a/16/root/usr/share/container-scripts/postgresql/README.md
+++ b/16/root/usr/share/container-scripts/postgresql/README.md
@@ -74,6 +74,15 @@ Set to an estimate of how much memory is available for disk caching by the opera
 **`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
  Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
 
+The following environment variables deal with extensions. They are all optional, and if not set, no extensions will be enabled.
+
+**`POSTGRESQL_LIBRARIES`**
+       A comma-separated list of libraries that Postgres will preload using shared_preload_libraries.
+
+**`POSTGRESQL_EXTENSIONS`**
+       A space-separated list of extensions to create when the server start. Once created, the extensions will stay even if the variable is cleared.
+
+
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 
 **`/var/lib/pgsql/data`**  

--- a/16/root/usr/share/container-scripts/postgresql/common.sh
+++ b/16/root/usr/share/container-scripts/postgresql/common.sh
@@ -144,6 +144,13 @@ function should_hack_data_sync_retry() {
   return 1
 }
 
+function generate_postgresql_libraries_config() {
+  if [ -v POSTGRESQL_LIBRARIES ]; then
+    echo "shared_preload_libraries='${POSTGRESQL_LIBRARIES}'" >> "${POSTGRESQL_CONFIG_FILE}"
+  fi
+}
+
+
 # New config is generated every time a container is created. It only contains
 # additional custom settings and is included from $PGDATA/postgresql.conf.
 function generate_postgresql_config() {
@@ -171,6 +178,7 @@ function generate_postgresql_config() {
     echo "log_filename = '$(basename "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
   fi
 
+  generate_postgresql_libraries_config
   (
   shopt -s nullglob
   for conf in "${APP_DATA}"/src/postgresql-cfg/*.conf; do
@@ -515,4 +523,13 @@ process_extending_files()
       fi
     done
   done <<<"$(get_matched_files '*.sh' "$@" | sort -u)"
+}
+
+create_extensions()
+{
+  if [ -v POSTGRESQL_EXTENSIONS ]; then
+    for EXT in $POSTGRESQL_EXTENSIONS; do
+      psql -c "CREATE EXTENSION IF NOT EXISTS ${EXT};"
+    done
+  fi
 }

--- a/src/root/usr/bin/run-postgresql
+++ b/src/root/usr/bin/run-postgresql
@@ -47,6 +47,7 @@ if $PG_INITIALIZED ; then
     create_users
 fi
 
+create_extensions
 process_extending_files \
     "${APP_DATA}/src/postgresql-start" \
     "${CONTAINER_SCRIPTS_PATH}/start"

--- a/src/root/usr/share/container-scripts/postgresql/README.md
+++ b/src/root/usr/share/container-scripts/postgresql/README.md
@@ -74,6 +74,15 @@ Set to an estimate of how much memory is available for disk caching by the opera
 **`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
  Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
 
+The following environment variables deal with extensions. They are all optional, and if not set, no extensions will be enabled.
+
+**`POSTGRESQL_LIBRARIES`**
+       A comma-separated list of libraries that Postgres will preload using shared_preload_libraries.
+
+**`POSTGRESQL_EXTENSIONS`**
+       A space-separated list of extensions to create when the server start. Once created, the extensions will stay even if the variable is cleared.
+
+
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 
 **`/var/lib/pgsql/data`**  

--- a/test/run_test
+++ b/test/run_test
@@ -28,6 +28,7 @@ run_s2i_enable_ssl_test
 run_upgrade_test
 run_migration_test
 run_pgaudit_test
+run_new_pgaudit_test
 run_logging_test
 "
 
@@ -36,6 +37,8 @@ test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
 test -n "${VERSION-}" || false 'make sure $VERSION is defined'
 test -n "${OS-}" || false 'make sure $OS is defined'
 
+
+DOCKER_EXTRA_ARGS=
 
 volumes_to_clean=
 images_to_clean=()
@@ -910,7 +913,7 @@ run_pgaudit_test()
   # create a dir for config
   config_dir=$(mktemp -d --tmpdir pg-hook-volume.XXXXX)
   add_cleanup_command /bin/rm -rf "$config_dir"
-  cp -r "$test_dir"/examples/pgaudit/* "$config_dir"
+  -v DOCKER_EXTRA_ARGS || cp -r "$test_dir"/examples/pgaudit/* "$config_dir"
   setfacl -R -m u:26:rwx "$config_dir"
 
   # create a dir for data
@@ -919,6 +922,7 @@ run_pgaudit_test()
 
   DOCKER_ARGS="
 -e POSTGRESQL_ADMIN_PASSWORD=password
+$DOCKER_EXTRA_ARGS
 -v ${config_dir}:/opt/app-root/src:Z
 -v ${data_dir}:/var/lib/pgsql/data:Z
   " create_container "$name"
@@ -930,7 +934,6 @@ run_pgaudit_test()
   # Deliberately moving heredoc into the container, otherwise it does not work
   # in podman 1.6.x due to https://bugzilla.redhat.com/show_bug.cgi?id=1827324
   docker exec -i $(get_cid "$name") bash -c "psql <<EOSQL
-CREATE EXTENSION pgaudit;
 SET pgaudit.log = 'read, ddl';
 CREATE DATABASE pgaudittest;
 EOSQL" || ret=2
@@ -994,6 +997,13 @@ run_logging_test()
   done
   echo "    PASS: the traditional log file under ${data_dir}/userdata/log/postgresql-*.log does not exist"
   echo "  Success!"
+}
+
+run_new_pgaudit_test() {
+    DOCKER_EXTRA_ARGS="
+-e POSTGRESQL_EXTENSIONS=pgaudit
+-e POSTGRESQL_LIBRARIES=pgaudit"
+    run_pgaudit_test
 }
 
 # configuration defaults


### PR DESCRIPTION
Using POSTGRESQL_LIBRARIES and POSTGRESQL_EXTENSIONS allow
users to enable extensions (some bundled in the container) without
having to do anything but adding 2 variables.