### PR TITLE
Revert "Deprecate imagestream 10 for RHEL7 and CentOS7."

### DIFF
--- a/imagestreams/postgresql-centos.json
+++ b/imagestreams/postgresql-centos.json
@@ -99,6 +99,42 @@
         }
       },
       {
+        "name": "10-el7",
+        "annotations": {
+          "openshift.io/display-name": "PostgreSQL 10 (CentOS 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a PostgreSQL 10 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+          "iconClass": "icon-postgresql",
+          "tags": "database,postgresql",
+          "version": "10"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/centos7/postgresql-10-centos7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10",
+        "annotations": {
+          "openshift.io/display-name": "PostgreSQL 10",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a PostgreSQL 10 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+          "iconClass": "icon-postgresql",
+          "tags": "database,postgresql,hidden",
+          "version": "10"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/centos7/postgresql-10-centos7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "9.6-el8",
         "annotations": {
           "openshift.io/display-name": "PostgreSQL 9.6 (CentOS 8)",

--- a/imagestreams/postgresql-rhel.json
+++ b/imagestreams/postgresql-rhel.json
@@ -99,6 +99,42 @@
         }
       },
       {
+        "name": "10-el7",
+        "annotations": {
+          "openshift.io/display-name": "PostgreSQL 10 (RHEL 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a PostgreSQL 10 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+          "iconClass": "icon-postgresql",
+          "tags": "database,postgresql",
+          "version": "10"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/postgresql-10-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10",
+        "annotations": {
+          "openshift.io/display-name": "PostgreSQL (Ephemeral) 10",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a PostgreSQL 10 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+          "iconClass": "icon-postgresql",
+          "tags": "database,postgresql,hidden",
+          "version": "10"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/postgresql-10-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "9.6-el8",
         "annotations": {
           "openshift.io/display-name": "PostgreSQL 9.6 (RHEL 8)",


### PR DESCRIPTION
This reverts commit 3525b011dd8e44e081cdfb7b55aa12719eeae5b7.

SCL rh-postgresql10 lifecycle is about to be extended.