### PR TITLE
Building testing pushing c8s support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PostgreSQL container images
 ========================
 
-PostgreSQL 10 status:[![Docker Repository on Quay](https://quay.io/repository/centos7/postgresql-10-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/postgresql-10-centos7), PostgreSQL 12 status:[![Docker Repository on Quay](https://quay.io/repository/centos7/postgresql-12-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/postgresql-12-centos7)
+[![Build and push images to Quay.io registry](https://github.com/sclorg/postgresql-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/postgresql-container/actions/workflows/build-and-push.yml)
 
 This repository contains Dockerfiles for PostgreSQL images for OpenShift.
 Users can choose between RHEL, Fedora and CentOS based images.

--- a/manifest.sh
+++ b/manifest.sh
@@ -41,6 +41,9 @@ DISTGEN_MULTI_RULES="
     src=src/Dockerfile
     dest=Dockerfile.c9s;
 
+    src=src/Dockerfile
+    dest=Dockerfile.c8s;
+
     src=src/Dockerfile.fedora
     dest=Dockerfile.fedora;
 "

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -63,6 +63,20 @@ specs:
       pkgs: "postgresql-server postgresql-contrib"
       environment_setup: >-4
           yum -y install postgresql && \
+    c8s:
+      distros:
+        - centos-stream-8-x86_64
+      s2i_base: quay.io/sclorg/s2i-core-c8s:c8s
+      org: "sclorg"
+      prod: "c8s"
+      openshift_tags: "database,postgresql,postgresql{{ spec.short }},postgresql-{{ spec.short }}"
+      redhat_component: "postgresql-{{ spec.short }}-container"
+      img_name: "{{ spec.org }}/postgresql-{{ spec.short }}-{{ spec.prod }}"
+      pkgs: "postgresql-server postgresql-contrib"
+      environment_setup: >-4
+          yum -y module enable postgresql:{{ spec.version }} && \
+      post_install: >-4
+          yum -y reinstall tzdata && \
 
     fedora:
       distros:
@@ -133,6 +147,7 @@ matrix:
         - rhel-7-x86_64
         - centos-7-x86_64
         - rhel-8-x86_64
+        - centos-stream-8-x86_64
         - centos-stream-9-x86_64
       version: "9.6"
     - distros:
@@ -145,11 +160,13 @@ matrix:
         - rhel-8-x86_64
         - centos-7-x86_64
         - fedora-34-x86_64
+        - centos-stream-8-x86_64
         - centos-stream-9-x86_64
       version: "11"
     - distros:
         - rhel-8-x86_64
         - fedora-34-x86_64
+        - centos-stream-8-x86_64
         - centos-stream-9-x86_64
       version: "12"
     - distros:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -73,7 +73,7 @@ RUN {{ spec.environment_setup }}
 {% if spec.version not in ["9.6", "10", "11"] %}
     {% if spec.prod == 'rhel7' or spec.prod == 'centos7' %}
     INSTALL_PKGS="$INSTALL_PKGS rh-postgresql{{ spec.short }}-pgaudit" && \
-    {% elif spec.prod == 'rhel8' or spec.prod == 'c9s' %}
+    {% elif spec.prod == 'rhel8' or spec.prod == 'c9s' or spec.prod == 'c8s' %}
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     {% endif %}
 {% endif %}
@@ -95,7 +95,7 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
-{% if spec.prod != "rhel8" and config.os.id != "fedora" %}
+{% if spec.prod != "rhel8" and config.os.id != "fedora" and spec.prod != "c8s" and spec.prod != "c9s" %}
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable
 # the SCL for all scripts without need to do 'scl enable'.


### PR DESCRIPTION
This pull request adds support for building, and testing CentOS Stream 8 postgresql-container.
It also adds support for pushing images into `quay.io/sclorg` repositories.

What is the difference between `13/Dockerfile.rhel8` and `13/Dockerfile.c8s`:
```bash
$ diff 13/Dockerfile.rhel8 13/Dockerfile.c8s
1c1
< FROM ubi8/s2i-core
---
> FROM quay.io/sclorg/s2i-core-c8s:c8s
13a14
>     POSTGRESQL_PREV_VERSION=12 \
30c31
<       name="rhel8/postgresql-13" \
---
>       name="sclorg/postgresql-13-c8s" \
33,34c34
<       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
<       usage="podman run -d --name postgresql_database -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -p 5432:5432 rhel8/postgresql-13" \
---
>       usage="podman run -d --name postgresql_database -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -p 5432:5432 sclorg/postgresql-13-c8s" \
49c49
```
What is the difference between `10/Dockerfile.rhel8` and `10/Dockerfile.c8s`:
```bash
$ diff 10/Dockerfile.rhel8 10/Dockerfile.c8s
1c1
< FROM ubi8/s2i-core
---
> FROM quay.io/sclorg/s2i-core-c8s:c8s
31c31
<       name="rhel8/postgresql-10" \
---
>       name="sclorg/postgresql-10-c8s" \
34,35c34
<       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
<       usage="podman run -d --name postgresql_database -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -p 5432:5432 rhel8/postgresql-10" \
---
>       usage="podman run -d --name postgresql_database -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -p 5432:5432 sclorg/postgresql-10-c8s" \
49c48
```
