### PR TITLE
Support building testing on fedora and quay

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -39,7 +39,7 @@ jobs:
             dockerfile: "Dockerfile.c9s"
             registry_namespace: "sclorg"
             tag: "c9s"
-            suffix: "c8s"
+            suffix: "c9s"
             quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
           - dockerfile_path: "11"

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -18,30 +18,52 @@ jobs:
             dockerfile: "Dockerfile"
             registry_namespace: "centos7"
             tag: "centos7"
+            suffix: "centos7"
             quayio_username: "QUAY_IMAGE_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_BUILDER_TOKEN"
           - dockerfile_path: "12"
             dockerfile: "Dockerfile"
             registry_namespace: "centos7"
             tag: "centos7"
+            suffix: "centos7"
             quayio_username: "QUAY_IMAGE_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_BUILDER_TOKEN"
           - dockerfile_path: "13"
             dockerfile: "Dockerfile"
             registry_namespace: "centos7"
             tag: "centos7"
+            suffix: "centos7"
             quayio_username: "QUAY_IMAGE_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_BUILDER_TOKEN"
           - dockerfile_path: "13"
             dockerfile: "Dockerfile.c9s"
             registry_namespace: "sclorg"
             tag: "c9s"
+            suffix: "c8s"
             quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+          - dockerfile_path: "11"
+            dockerfile: "Dockerfile.fedora"
+            registry_namespace: "fedora"
+            tag: "11"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+          - dockerfile_path: "12"
+            dockerfile: "Dockerfile.fedora"
+            registry_namespace: "fedora"
+            tag: "12"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+          - dockerfile_path: "13"
+            dockerfile: "Dockerfile.fedora"
+            registry_namespace: "fedora"
+            tag: "13"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
 
     steps:
       - name: Build and push to quay.io registry
-        uses: sclorg/build-and-push-action@v1
+        uses: sclorg/build-and-push-action@v2
         with:
           registry: "quay.io"
           registry_namespace: ${{ matrix.registry_namespace }}
@@ -52,3 +74,4 @@ jobs:
           dockerfile_path: ${{ matrix.dockerfile_path }}
           tag: ${{ matrix.tag }}
           use_distgen: "true"
+          suffix: ${{ matrix.suffix }}

--- a/src/Dockerfile.fedora
+++ b/src/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/{{ spec.latest_fedora }}/s2i-core:latest
+FROM quay.io/fedora/s2i-core:35
 
 # PostgreSQL image for OpenShift.
 # Volumes:
@@ -33,9 +33,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,postgresql,postgresql{{ spec.short }}" \
       com.redhat.component="$NAME" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
-      name="$FGC/$NAME" \
+      name="fedora/$NAME-{{ spec.short }}" \
       version="0" \
-      usage="docker run -d --name postgresql_database -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -p 5432:5432 $FGC/$NAME"
+      usage="docker run -d --name postgresql_database -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -p 5432:5432 quay.io/fedora/$NAME-{{ spec.short }}"
 
 EXPOSE 5432
 


### PR DESCRIPTION
Support building, testing postgresql-container on Fedora host.

Please check if build-and-push-action contains proper versions.
This pull request automatically pushes these versions: `11`, `12`, `13`.

https://github.com/sclorg/postgresql-container/pull/438