### PR TITLE
Update description of POSTGRESQL_SHARED_BUFFERS & POSTGRESQL_EFFECTIVE_CACHE_SIZE default values

### DIFF
--- a/src/root/usr/share/container-scripts/postgresql/README.md
+++ b/src/root/usr/share/container-scripts/postgresql/README.md
@@ -95,10 +95,10 @@ The following environment variables influence the PostgreSQL configuration file.
 **`POSTGRESQL_MAX_PREPARED_TRANSACTIONS (default: 0)`**  
        Sets the maximum number of transactions that can be in the "prepared" state. If you are using prepared transactions, you will probably want this to be at least as large as max_connections
 
-**`POSTGRESQL_SHARED_BUFFERS (default: 32M)`**  
+**`POSTGRESQL_SHARED_BUFFERS (default: 1/4 of memory limit or 32M)`**
        Sets how much memory is dedicated to PostgreSQL to use for caching data
 
-**`POSTGRESQL_EFFECTIVE_CACHE_SIZE (default: 128M)`**  
+**`POSTGRESQL_EFFECTIVE_CACHE_SIZE (default: 1/2 of memory limit or 128M)`**
        Set to an estimate of how much memory is available for disk caching by the operating system and within the database itself
 
 


### PR DESCRIPTION
The previous description was not completely correct, because when the container is run in Kubernetes/Openshift, the default values [are calculated](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/common.sh#L12) based on [memory limit](https://github.com/sclorg/container-common-scripts/blob/master/shared-scripts/core/usr/bin/cgroup-limits).