### PR TITLE
Use OpenShift internal registry instead of external

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -22,8 +22,8 @@ ct_os_check_compulsory_vars
 
 oc status || false "It looks like oc is not properly logged in."
 
-# For testing on OpenShift 4 we use external registry
-export CT_EXTERNAL_REGISTRY=true
+# For testing on OpenShift 4 we use internal registry
+export CT_OCP4_TEST=true
 
 # Check the template
 test_postgresql_integration "${IMAGE_NAME}"


### PR DESCRIPTION
Nowadays, we use the external OpenShift registry for the testing image.
OpenShift 4 provides an internal OpenShift registry. Let's use it.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>