### PR TITLE
Update Dockerfile.rhel8 to fix the postgresql upgrade issue from v12 to v13.

### DIFF
--- a/13/Dockerfile.rhel8
+++ b/13/Dockerfile.rhel8
@@ -11,6 +11,7 @@ FROM ubi8/s2i-core
 #                           PostgreSQL administrative account
 
 ENV POSTGRESQL_VERSION=13 \
+    POSTGRESQL_PREV_VERSION=12 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres \
     APP_DATA=/opt/app-root


### PR DESCRIPTION
I was trying to test postgresql upgrade to version 13 from version 12 using RHEL8 based image but it's not working.  I see the following env is missing in RHEL8 based postgresql 13 image

POSTGRESQL_PREV_VERSION=12

Here is the link to problematic Dockerfile.

https://github.com/sclorg/postgresql-container/blob/generated/13/Dockerfile.rhel8

The same works fine with RHEL7 and other images.