### PR TITLE
Support building testing postgresql-13 on RHEL9 host

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@ PostgreSQL container images
 
 [![Build and push images to Quay.io registry](https://github.com/sclorg/postgresql-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/postgresql-container/actions/workflows/build-and-push.yml)
 
+Images available on Quay are:
+* CentOS 7 [postgresql-10](https://quay.io/repository/centos7/postgresql-10-centos7)
+* CentOS 7 [postgresql-12](https://quay.io/repository/centos7/postgresql-12-centos7)
+* CentOS 7 [postgresql-13](https://quay.io/repository/centos7/postgresql-13-centos7)
+* CentOS Stream 8 [postgresql-10](https://quay.io/repository/sclorg/postgresql-10-c8s)
+* CentOS Stream 8 [postgresql-13](https://quay.io/repository/sclorg/postgresql-13-c8s)
+* CentOS Stream 9 [postgresql-13](https://quay.io/repository/sclorg/postgresql-13-c9s)
+* Fedora [postgresql-11](https://quay.io/repository/fedora/postgresql-11)
+* Fedora [postgresql-12](https://quay.io/repository/fedora/postgresql-12)
+* Fedora [postgresql-13](https://quay.io/repository/fedora/postgresql-13)
+
 This repository contains Dockerfiles for PostgreSQL images for OpenShift.
 Users can choose between RHEL, Fedora and CentOS based images.
 
@@ -25,9 +36,12 @@ PostgreSQL versions currently supported are:
 RHEL versions currently supported are:
 * RHEL7
 * RHEL8
+* RHEL9
 
 CentOS versions currently supported are:
 * CentOS7
+* CentOS Stream 8
+* CentOS Stream 9
 
 
 Installation

--- a/manifest.sh
+++ b/manifest.sh
@@ -39,6 +39,9 @@ DISTGEN_MULTI_RULES="
     dest=Dockerfile.rhel8;
 
     src=src/Dockerfile
+    dest=Dockerfile.rhel9;
+
+    src=src/Dockerfile
     dest=Dockerfile.c9s;
 
     src=src/Dockerfile

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -51,6 +51,20 @@ specs:
            yum -y module enable postgresql:{{ spec.version }} && \
        post_install: >-4
            yum -y reinstall tzdata && \
+    rhel9:
+       distros:
+         - rhel-9-x86_64
+       s2i_base: ubi9/s2i-core
+       org: "rhel9"
+       prod: "rhel9"
+       openshift_tags: "database,postgresql,postgresql{{ spec.short }},postgresql-{{ spec.short }}"
+       redhat_component: "postgresql-{{ spec.short }}-container"
+       img_name: "{{ spec.org }}/postgresql-{{ spec.short }}"
+       pkgs: "postgresql-server postgresql-contrib"
+       environment_setup: >-4
+           yum -y install postgresql && \
+       post_install: >-4
+           yum -y reinstall tzdata && \
     c9s:
       distros:
         - centos-stream-9-x86_64
@@ -147,17 +161,20 @@ matrix:
         - rhel-7-x86_64
         - centos-7-x86_64
         - rhel-8-x86_64
+        - rhel-9-x86_64
         - centos-stream-8-x86_64
         - centos-stream-9-x86_64
       version: "9.6"
     - distros:
         - fedora-31-x86_64
         - fedora-34-x86_64
+        - rhel-9-x86_64
         - centos-stream-9-x86_64
       version: "10"
     - distros:
         - rhel-7-x86_64
         - rhel-8-x86_64
+        - rhel-9-x86_64
         - centos-7-x86_64
         - fedora-34-x86_64
         - centos-stream-8-x86_64
@@ -165,6 +182,7 @@ matrix:
       version: "11"
     - distros:
         - rhel-8-x86_64
+        - rhel-9-x86_64
         - fedora-34-x86_64
         - centos-stream-8-x86_64
         - centos-stream-9-x86_64

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -11,7 +11,7 @@ FROM {{ spec.s2i_base }}
 #                           PostgreSQL administrative account
 
 ENV POSTGRESQL_VERSION={{ spec.version }} \
-    {% if spec.prod != "rhel8" or spec.version == "10" %}
+    {% if spec.prod != "rhel8" or spec.prod != "rhel9" or spec.version == "10" %}
     POSTGRESQL_PREV_VERSION={{ spec.prev_version }} \
     {% endif %}
     HOME=/var/lib/pgsql \
@@ -73,7 +73,7 @@ RUN {{ spec.environment_setup }}
 {% if spec.version not in ["9.6", "10", "11"] %}
     {% if spec.prod == 'rhel7' or spec.prod == 'centos7' %}
     INSTALL_PKGS="$INSTALL_PKGS rh-postgresql{{ spec.short }}-pgaudit" && \
-    {% elif spec.prod == 'rhel8' or spec.prod == 'c9s' or spec.prod == 'c8s' %}
+    {% elif spec.prod == 'rhel8' or spec.prod == 'rhel9' or spec.prod == 'c9s' or spec.prod == 'c8s' %}
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     {% endif %}
 {% endif %}
@@ -95,7 +95,7 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
-{% if spec.prod != "rhel8" and config.os.id != "fedora" and spec.prod != "c8s" and spec.prod != "c9s" %}
+{% if spec.prod != "rhel8" and spec.prod != "rhel9" and config.os.id != "fedora" and spec.prod != "c8s" and spec.prod != "c9s" %}
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable
 # the SCL for all scripts without need to do 'scl enable'.

--- a/src/root/usr/share/container-scripts/postgresql/README.md
+++ b/src/root/usr/share/container-scripts/postgresql/README.md
@@ -5,7 +5,7 @@ This container image includes PostgreSQL {{ spec.version }} SQL database server 
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
 the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
-and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
+and the Fedora images are available in [Quay.io](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
 Note: while the examples in this README are calling `podman`, you can replace any such calls by `docker` with the same arguments
@@ -327,4 +327,5 @@ Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/postgresql-container.
 In that repository, the Dockerfile for CentOS is called Dockerfile, the Dockerfile
 for RHEL7 is called Dockerfile.rhel7, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
+the Dockerfile for RHEL9 is called Dockerfile.rhel9,
 and the Dockerfile for Fedora is called Dockerfile.fedora.


### PR DESCRIPTION
This pull request adds support for building and testing postgresql-13 container on RHEL9 host.

It updates also README.md documentation with references.