### PR TITLE
Update Dockerfile.rhel8 to fix the postgresql upgrade issue from v12 to v13.

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -11,7 +11,7 @@ FROM {{ spec.s2i_base }}
 #                           PostgreSQL administrative account
 
 ENV POSTGRESQL_VERSION={{ spec.version }} \
-    {% if spec.prod != "rhel8" or spec.prod != "rhel9" or spec.version == "10" %}
+    {% if spec.prod != "rhel8" or spec.prod != "rhel9" or spec.version == "10" or spec.version == "13" %}
     POSTGRESQL_PREV_VERSION={{ spec.prev_version }} \
     {% endif %}
     HOME=/var/lib/pgsql \

--- a/test/run_test
+++ b/test/run_test
@@ -652,7 +652,7 @@ run_upgrade_test ()
 {
     # Do not run on Fedora or RHEL8 until the upgrade script
     # is fixed for non-SCL use cases
-    { [ "${OS}" == "fedora" ] } && return 0
+    { [ "${OS}" == "fedora" ]; } && return 0
 
     local upgrade_path="none 9.2 9.4 9.5 9.6 10 12 13 none" prev= act=
     for act in $upgrade_path; do

--- a/test/run_test
+++ b/test/run_test
@@ -652,7 +652,7 @@ run_upgrade_test ()
 {
     # Do not run on Fedora or RHEL8 until the upgrade script
     # is fixed for non-SCL use cases
-    { [ "${OS}" == "fedora" ] || [ "${OS}" == "rhel8" ]; } && return 0
+    { [ "${OS}" == "fedora" ] } && return 0
 
     local upgrade_path="none 9.2 9.4 9.5 9.6 10 12 13 none" prev= act=
     for act in $upgrade_path; do


### PR DESCRIPTION
Updated docker file to set the POSTGRESQL_PREV_VERSION environment variable for postgresql version 13.

Here is the OLD PR: #451


<!-- issue-commentator = {"comment-id":"2462038536"} -->