### PR TITLE
Add a test in Dockerfile directly to check the version

### DIFF
--- a/10/Dockerfile.c8s
+++ b/10/Dockerfile.c8s
@@ -45,6 +45,7 @@ RUN yum -y module enable postgresql:10 && \
     INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y reinstall tzdata && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/10/Dockerfile.centos7
+++ b/10/Dockerfile.centos7
@@ -45,6 +45,7 @@ RUN yum install -y centos-release-scl-rh && \
     INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper rh-postgresql10 rh-postgresql10-postgresql-contrib rh-postgresql10-syspaths rh-postgresql96-postgresql-server" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \

--- a/10/Dockerfile.rhel7
+++ b/10/Dockerfile.rhel7
@@ -49,6 +49,7 @@ RUN yum install -y yum-utils gettext && \
     INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper rh-postgresql10 rh-postgresql10-postgresql-contrib rh-postgresql10-syspaths rh-postgresql96-postgresql-server" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \

--- a/10/Dockerfile.rhel8
+++ b/10/Dockerfile.rhel8
@@ -46,6 +46,7 @@ RUN yum -y module enable postgresql:10 && \
     INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y reinstall tzdata && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/12/Dockerfile.c8s
+++ b/12/Dockerfile.c8s
@@ -46,6 +46,7 @@ RUN yum -y module enable postgresql:12 && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y reinstall tzdata && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/12/Dockerfile.centos7
+++ b/12/Dockerfile.centos7
@@ -46,6 +46,7 @@ RUN yum install -y centos-release-scl-rh && \
     INSTALL_PKGS="$INSTALL_PKGS rh-postgresql12-pgaudit" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \

--- a/12/Dockerfile.fedora
+++ b/12/Dockerfile.fedora
@@ -50,6 +50,7 @@ RUN INSTALL_PKGS="rsync tar gettext bind-utils postgresql-server postgresql-cont
     dnf -y module enable postgresql:12 && \
     dnf -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     dnf clean all && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
     mkdir -p /var/lib/pgsql/data && \

--- a/12/Dockerfile.rhel7
+++ b/12/Dockerfile.rhel7
@@ -50,6 +50,7 @@ RUN yum install -y yum-utils gettext && \
     INSTALL_PKGS="$INSTALL_PKGS rh-postgresql12-pgaudit" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \

--- a/12/Dockerfile.rhel8
+++ b/12/Dockerfile.rhel8
@@ -47,6 +47,7 @@ RUN yum -y module enable postgresql:12 && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y reinstall tzdata && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/13/Dockerfile.c8s
+++ b/13/Dockerfile.c8s
@@ -46,6 +46,7 @@ RUN yum -y module enable postgresql:13 && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y reinstall tzdata && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/13/Dockerfile.c9s
+++ b/13/Dockerfile.c9s
@@ -46,6 +46,7 @@ RUN  { yum -y module enable postgresql:13 || :; } && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \

--- a/13/Dockerfile.centos7
+++ b/13/Dockerfile.centos7
@@ -46,6 +46,7 @@ RUN yum install -y centos-release-scl-rh && \
     INSTALL_PKGS="$INSTALL_PKGS rh-postgresql13-pgaudit" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \

--- a/13/Dockerfile.fedora
+++ b/13/Dockerfile.fedora
@@ -50,6 +50,7 @@ RUN INSTALL_PKGS="rsync tar gettext bind-utils postgresql-server postgresql-cont
     dnf -y module enable postgresql:13 && \
     dnf -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     dnf clean all && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
     mkdir -p /var/lib/pgsql/data && \

--- a/13/Dockerfile.rhel7
+++ b/13/Dockerfile.rhel7
@@ -50,6 +50,7 @@ RUN yum install -y yum-utils gettext && \
     INSTALL_PKGS="$INSTALL_PKGS rh-postgresql13-pgaudit" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \

--- a/13/Dockerfile.rhel8
+++ b/13/Dockerfile.rhel8
@@ -47,6 +47,7 @@ RUN yum -y module enable postgresql:13 && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y reinstall tzdata && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/13/Dockerfile.rhel9
+++ b/13/Dockerfile.rhel9
@@ -47,6 +47,7 @@ RUN { yum -y module enable postgresql:13 || :; } && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y reinstall tzdata && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -79,6 +79,7 @@ RUN {{ spec.environment_setup }}
 {% endif %}
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     {% if spec.post_install %}
     {{ spec.post_install }}
     {% endif %}

--- a/src/Dockerfile.fedora
+++ b/src/Dockerfile.fedora
@@ -52,6 +52,7 @@ RUN INSTALL_PKGS="rsync tar gettext bind-utils postgresql-server postgresql-cont
     dnf -y module enable postgresql:{{ spec.version }} && \
     dnf -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     dnf clean all && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
     mkdir -p /var/lib/pgsql/data && \


### PR DESCRIPTION
Otherwise when a wrong stream is installed, it's only found by scl test, which is too late in the process and might even go through uncought, especially when the scl test is removed for non-SCL distros at some point.