### PR TITLE
tests: change rhel9.0 compose to rhel9.1 compose

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -46,7 +46,7 @@ jobs:
           - tmt_plan: "rhel9-docker"
             os_test: "rhel9"
             context: "RHEL9"
-            compose: "RHEL-9.0.0-Nightly"
+            compose: "RHEL-9.1.0-Nightly"
             api_key: "TF_INTERNAL_API_KEY"
             branch: "master"
             tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"


### PR DESCRIPTION
Change the TF compose to rhel-9.1.0-Nightly to find out, if the problem with tests on RHEL9 machine is present here too.