### PR TITLE
Add support for building, testing and pushing postgresql-15

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -70,6 +70,13 @@ jobs:
             quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
             image_name: "postgresql-13"
             docker_context: 13
+          - dockerfile: "15/Dockerfile.fedora"
+            registry_namespace: "fedora"
+            tag: "15"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            image_name: "postgresql-15"
+            docker_context: 15
 
     steps:
       - name: Build and push to quay.io registry

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "10", "11", "12", "13" ]
+        version: [ "10", "11", "12", "13", "15" ]
         os_test: [ "fedora", "centos7", "rhel7", "rhel8", "rhel9", "c9s", "c8s"]
         include:
           - tmt_plan: "fedora"

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "10", "11", "12", "13" ]
+        version: [ "10", "11", "12", "13", "15" ]
         os_test: [ "centos7", "rhel7", "rhel8", "rhel9"]
         include:
           - tmt_plan: "centos7"


### PR DESCRIPTION
This pull request adds support for building, testing Postgresql-15.

Push to the quay.io/fedora registry is already part of this pull request.

The quay.io/fedora/postgresql-15 already exists https://quay.io/repository/fedora/postgresql-15?tab=info