### PR TITLE
Allow loading secrets from mounted files rather than ENV vars

### DIFF
--- a/10/root/usr/bin/run-postgresql
+++ b/10/root/usr/bin/run-postgresql
@@ -2,6 +2,15 @@
 
 export ENABLE_REPLICATION=${ENABLE_REPLICATION:-false}
 
+# Load secrets from files mounted on the filesystem and only expose them to this process.
+# This allows kubernetes to mount secrets as files in a directory rather than exposing them in the ENV.
+# For example: mount secret with key username as /run/secrets/postgresql/POSTGRESQL_USER
+for file in /run/secrets/postgresql/*
+do
+    [ -e "$file" ] || continue
+    export "$(basename $file)=$(cat $file)"
+done
+
 set -eu
 export_vars=$(cgroup-limits) ; export $export_vars
 

--- a/12/root/usr/bin/run-postgresql
+++ b/12/root/usr/bin/run-postgresql
@@ -2,6 +2,15 @@
 
 export ENABLE_REPLICATION=${ENABLE_REPLICATION:-false}
 
+# Load secrets from files mounted on the filesystem and only expose them to this process.
+# This allows kubernetes to mount secrets as files in a directory rather than exposing them in the ENV.
+# For example: mount secret with key username as /run/secrets/postgresql/POSTGRESQL_USER
+for file in /run/secrets/postgresql/*
+do
+    [ -e "$file" ] || continue
+    export "$(basename $file)=$(cat $file)"
+done
+
 set -eu
 export_vars=$(cgroup-limits) ; export $export_vars
 

--- a/13/root/usr/bin/run-postgresql
+++ b/13/root/usr/bin/run-postgresql
@@ -2,6 +2,15 @@
 
 export ENABLE_REPLICATION=${ENABLE_REPLICATION:-false}
 
+# Load secrets from files mounted on the filesystem and only expose them to this process.
+# This allows kubernetes to mount secrets as files in a directory rather than exposing them in the ENV.
+# For example: mount secret with key username as /run/secrets/postgresql/POSTGRESQL_USER
+for file in /run/secrets/postgresql/*
+do
+    [ -e "$file" ] || continue
+    export "$(basename $file)=$(cat $file)"
+done
+
 set -eu
 export_vars=$(cgroup-limits) ; export $export_vars
 

--- a/src/root/usr/bin/run-postgresql
+++ b/src/root/usr/bin/run-postgresql
@@ -2,6 +2,15 @@
 
 export ENABLE_REPLICATION=${ENABLE_REPLICATION:-false}
 
+# Load secrets from files mounted on the filesystem and only expose them to this process.
+# This allows kubernetes to mount secrets as files in a directory rather than exposing them in the ENV.
+# For example: mount secret with key username as /run/secrets/postgresql/POSTGRESQL_USER
+for file in /run/secrets/postgresql/*
+do
+    [ -e "$file" ] || continue
+    export "$(basename $file)=$(cat $file)"
+done
+
 set -eu
 export_vars=$(cgroup-limits) ; export $export_vars
 


### PR DESCRIPTION
This allows keys from kubernetes secrets to be mounted as files to avoid exposing them in the ENV.

<!-- issue-commentator = {"comment-id":"2462038650"} -->