### PR TITLE
Demonstrate broken tests didn't show red

### DIFF
--- a/14/root/usr/share/container-scripts/postgresql/README.md
+++ b/14/root/usr/share/container-scripts/postgresql/README.md
@@ -101,6 +101,9 @@ The following environment variables influence the PostgreSQL configuration file.
 **`POSTGRESQL_EFFECTIVE_CACHE_SIZE (default: 1/2 of memory limit or 128M)`**
        Set to an estimate of how much memory is available for disk caching by the operating system and within the database itself
 
+**`POSTGRESQL_LOG_DESTINATION (default: /var/lib/pgsql/data/userdata/log/postgresql-*.log)`**  
+       Where to log errors, the default is `/var/lib/pgsql/data/userdata/log/postgresql-*.log` and this file is rotated; it can be changed to `/dev/stderr` to make debugging easier
+
 
 You can also set the following mount points by passing the `-v /host/dir:/container/dir:Z` flag to Docker.
 

--- a/14/root/usr/share/container-scripts/postgresql/common.sh
+++ b/14/root/usr/share/container-scripts/postgresql/common.sh
@@ -18,6 +18,8 @@ else
     export POSTGRESQL_EFFECTIVE_CACHE_SIZE=${POSTGRESQL_EFFECTIVE_CACHE_SIZE:-$effective_cache}
 fi
 
+export POSTGRESQL_LOG_DESTINATION=${POSTGRESQL_LOG_DESTINATION:-}
+
 export POSTGRESQL_RECOVERY_FILE=$HOME/openshift-custom-recovery.conf
 export POSTGRESQL_CONFIG_FILE=$HOME/openshift-custom-postgresql.conf
 
@@ -159,6 +161,16 @@ function generate_postgresql_config() {
     echo "data_sync_retry = on" >>"${POSTGRESQL_CONFIG_FILE}"
   fi
 
+  # For easier debugging, allow users to log to stderr (will be visible
+  # in the pod logs) using a single variable
+  # https://github.com/sclorg/postgresql-container/issues/353
+  if [ -n "${POSTGRESQL_LOG_DESTINATION:-}" ] ; then
+    echo "log_destination = 'stderr'" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "logging_collector = on" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "log_directory = '$(dirname "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
+    echo "log_filename = '$(basename "${POSTGRESQL_LOG_DESTINATION}")'" >>"${POSTGRESQL_CONFIG_FILE}"
+  fi
+
   (
   shopt -s nullglob
   for conf in "${APP_DATA}"/src/postgresql-cfg/*.conf; do
@@ -177,7 +189,7 @@ function generate_postgresql_recovery_config() {
 function generate_passwd_file() {
   export USER_ID=$(id -u)
   export GROUP_ID=$(id -g)
-  grep -v -e ^postgres -e ^$USER_ID /etc/passwd > "$HOME/passwd"
+  grep -v -e ^postgres -e ^$USER_ID -e ^$(id -un) /etc/passwd > "$HOME/passwd"
   echo "postgres:x:${USER_ID}:${GROUP_ID}:PostgreSQL Server:${HOME}:/bin/bash" >> "$HOME/passwd"
   export LD_PRELOAD=libnss_wrapper.so
   export NSS_WRAPPER_PASSWD=${HOME}/passwd

--- a/test/run_test
+++ b/test/run_test
@@ -482,7 +482,7 @@ function test_value_replication() {
   # Setup the replication data
   local value
   value=24
-  postgresql_cmd -c "CREATE TABLE $table_name (a integer); INSERT INTO $table_name VALUES ($value);"
+  postgresql_cmd -c "BREAKING TESTS CREATE TABLE $table_name (a integer); INSERT INTO $table_name VALUES ($value);"
 
   # Read value from slaves and check whether it is expected
   for slave in $slave_cids; do


### PR DESCRIPTION
See the list of tests include many tests:

```
TEST_LIST="\
run_container_creation_tests
run_general_tests
run_change_password_test
run_replication_test
run_master_restart_test
run_doc_test
run_s2i_test
run_test_cfg_hook
run_s2i_bake_data_test
run_s2i_enable_ssl_test
run_upgrade_test
run_migration_test
run_pgaudit_test
"
```

Then check the results log of some of the green tasks, like https://artifacts.dev.testing-farm.io/fded2fa4-7148-4f0e-8e94-adb5ae50e7e2/, which includes:

```
 [PASSED] for 'postgresql-container_tests' run_container_creation_tests (00:00:31)
 [PASSED] for 'postgresql-container_tests' run_general_tests (00:01:38)
 [PASSED] for 'postgresql-container_tests' run_change_password_test (00:00:10)
```

and not others. Also, mind the error in the log, which is just before the cleanup starts:

```
ERROR:  syntax error at or near "BREAKING"
LINE 1: BREAKING TESTS CREATE TABLE t1 (a integer); INSERT INTO t1 V...
        ^
```

This means the test suite fails in 4th test, which fails and yet the whole suite returns green.