### PR TITLE
Replace uname -i/-p with -m

### DIFF
--- a/10/root/usr/share/container-scripts/postgresql/common.sh
+++ b/10/root/usr/share/container-scripts/postgresql/common.sh
@@ -130,7 +130,7 @@ version2number ()
 # These cases are: non-intel architectures, and version higher or equal 12.0, 10.7, 9.6.12
 # Return value 0 means the hack is needed.
 function should_hack_data_sync_retry() {
-  [ "$(uname -p)" == 'x86_64' ] && return 1
+  [ "$(uname -m)" == 'x86_64' ] && return 1
   local version_number=$(version2number "$(pg_ctl -V | sed -e 's/^pg_ctl (PostgreSQL) //')")
   # this matches all 12.x and versions of 10.x where we need the hack
   [ "$version_number" -ge 100700 ] && return 0

--- a/12/root/usr/share/container-scripts/postgresql/common.sh
+++ b/12/root/usr/share/container-scripts/postgresql/common.sh
@@ -130,7 +130,7 @@ version2number ()
 # These cases are: non-intel architectures, and version higher or equal 12.0, 10.7, 9.6.12
 # Return value 0 means the hack is needed.
 function should_hack_data_sync_retry() {
-  [ "$(uname -p)" == 'x86_64' ] && return 1
+  [ "$(uname -m)" == 'x86_64' ] && return 1
   local version_number=$(version2number "$(pg_ctl -V | sed -e 's/^pg_ctl (PostgreSQL) //')")
   # this matches all 12.x and versions of 10.x where we need the hack
   [ "$version_number" -ge 100700 ] && return 0

--- a/13/root/usr/share/container-scripts/postgresql/common.sh
+++ b/13/root/usr/share/container-scripts/postgresql/common.sh
@@ -130,7 +130,7 @@ version2number ()
 # These cases are: non-intel architectures, and version higher or equal 12.0, 10.7, 9.6.12
 # Return value 0 means the hack is needed.
 function should_hack_data_sync_retry() {
-  [ "$(uname -p)" == 'x86_64' ] && return 1
+  [ "$(uname -m)" == 'x86_64' ] && return 1
   local version_number=$(version2number "$(pg_ctl -V | sed -e 's/^pg_ctl (PostgreSQL) //')")
   # this matches all 12.x and versions of 10.x where we need the hack
   [ "$version_number" -ge 100700 ] && return 0

--- a/15/root/usr/share/container-scripts/postgresql/common.sh
+++ b/15/root/usr/share/container-scripts/postgresql/common.sh
@@ -130,7 +130,7 @@ version2number ()
 # These cases are: non-intel architectures, and version higher or equal 12.0, 10.7, 9.6.12
 # Return value 0 means the hack is needed.
 function should_hack_data_sync_retry() {
-  [ "$(uname -p)" == 'x86_64' ] && return 1
+  [ "$(uname -m)" == 'x86_64' ] && return 1
   local version_number=$(version2number "$(pg_ctl -V | sed -e 's/^pg_ctl (PostgreSQL) //')")
   # this matches all 12.x and versions of 10.x where we need the hack
   [ "$version_number" -ge 100700 ] && return 0

--- a/src/root/usr/share/container-scripts/postgresql/common.sh
+++ b/src/root/usr/share/container-scripts/postgresql/common.sh
@@ -131,7 +131,7 @@ version2number ()
 # These cases are: non-intel architectures, and version higher or equal 12.0, 10.7, 9.6.12
 # Return value 0 means the hack is needed.
 function should_hack_data_sync_retry() {
-  [ "$(uname -p)" == 'x86_64' ] && return 1
+  [ "$(uname -m)" == 'x86_64' ] && return 1
   local version_number=$(version2number "$(pg_ctl -V | sed -e 's/^pg_ctl (PostgreSQL) //')")
   # this matches all 12.x and versions of 10.x where we need the hack
   [ "$version_number" -ge 100700 ] && return 0

--- a/test/run_test
+++ b/test/run_test
@@ -693,7 +693,7 @@ run_migration_test ()
 
     local from_version
     # Only test a subset of the migration path on non-intel hosts
-    if [ "$(uname -i)" == "x86_64" ]; then
+    if [ "$(uname -m)" == "x86_64" ]; then
         local upgrade_path="9.2 9.4 9.5 9.6 10 12 13 15"
     else
         local upgrade_path="10 12 13 15"


### PR DESCRIPTION
uname -i functionality is non-portable and the custom patch Fedora was carrying around was recently dropped:

https://src.fedoraproject.org/rpms/coreutils/c/cd953e11dd78cada371f0389171cea671949141b?branch=rawhide

The rhbz#548834 suggests to use uname -m instead.

Also relevant discussion happens at rhbz#2158752