### PR TITLE
docs: Rewrite SSL documentation

### DIFF
--- a/examples/enable-ssl/README.md
+++ b/examples/enable-ssl/README.md
@@ -1,10 +1,16 @@
-#### enable-ssl
+# Enabling SSL/TLS for PostgreSQL container
 
-This example demonstrates how to extend the postgresql container by enabling SSL/TLS.  
+This example demonstrates extending the PostgreSQL container by enabling SSL/TLS.
 
-The following instructions assumes the use of OpenShift.  
+## Initial configuration
 
-1. Deploy postgres:  
+In this example, we will assume that you are using OpenShift. Suppose you do not have Openshift enabled or installed. In that case, you can install it on RHEL via the tutorial [here](https://docs.openshift.com/container-platform/4.12/installing/index.html) or on Fedora with `dnf install origin-clients` ([Openshift Fedora Developer](https://developer.fedoraproject.org/deployment/ocopenshift/about.html)) and `dnf install podman-docker`. You also need to have a valid KUBECONFIG file.
+
+## Example of how to enable SSL to PostgreSQL
+
+1. Deploy postgres:
+   You should use your configuration for `myUser`, `myPassword` and `myDB`
+
 ```bash
 oc new-app --name psql-ssl postgresql:13-el7~https://github.com/sclorg/postgresql-container.git \
   --context-dir examples/enable-ssl \
@@ -13,14 +19,16 @@ oc new-app --name psql-ssl postgresql:13-el7~https://github.com/sclorg/postgresq
   -e POSTGRESQL_DATABASE=myDB
 ```
 
-2. Create your secrets:  
+2. Create your secrets:
+
 ```bash
 openssl genrsa -out tls.key 2048
 openssl req -new -x509 -key tls.key -out tls.cert
 oc create secret tls db-ssl-keys --key tls.key --cert tls.cert
 ```
 
-3. Bind your secrets into postgres deploymentConfig:  
+3. Bind your secrets into postgres deploymentConfig:
+
 ```bash
 oc set volume --add \
     --type=secret \
@@ -28,24 +36,4 @@ oc set volume --add \
     --default-mode=0640 \
     --mount-path=/opt/app-root/src/certs/ \
     dc/psql-ssl
-```
-
-By default the `postgresql-pre-start/enable_ssl.sh` needs a service account with `anyuid` SCC.  
-To use in the default `restriced` mode jump to step `5.`  
-_The step 4. example must be executed by a cluster-admin role._  
-  
-4. Create the service account and attach to the deploymentConfig:  
-```bash
-oc create sa psql-ssl-sa
-oc adm policy add-scc-to-user anyuid -z psql-ssl-sa
-oc set sa dc/psql-ssl psql-ssl-sa
-```
-  
-5. Overwriting the `pre-start` scripts enabling the execution with `restricted` SCC mode:  
-```bash
-oc create secret generic psql-custom-prestart --from-literal empty="overwriting-prestart"
-oc set volume dc/psql-ssl --add \
-  --type secret \
-  --secret-name psql-custom-prestart \
-  --mount-path /opt/app-root/src/postgresql-pre-start/
 ```


### PR DESCRIPTION
I have rewritten the README.md documentation for SSL/TLS example. Minor changes.
