### PR TITLE
This test `run_master_restart_test` is removed from the test suite

### DIFF
--- a/test/run_test
+++ b/test/run_test
@@ -20,7 +20,6 @@ run_container_creation_tests
 run_general_tests
 run_change_password_test
 run_replication_test
-run_master_restart_test
 run_doc_test
 run_s2i_test
 run_test_cfg_hook
@@ -520,6 +519,9 @@ function setup_replication_cluster() {
 
 }
 
+# This test is removed from the test suite
+# In our CI is failing sporadically and solution is not available yet.
+# Let's remove it from test but the test function remains.
 function run_master_restart_test() {
   local DB=postgres
   local PGUSER=master


### PR DESCRIPTION
This test is removed from the test suite.
In our CI is failing sporadically and solution is not available yet.
Let's remove it from test but the test function remains.