### PR TITLE
Update build-and-push.yml

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -107,7 +107,22 @@ jobs:
             docker_context: 15
 
     steps:
-      - name: Build and push to quay.io registry
+      - name: check if Dockerfile is c9s, then Build multi arch image and push to quay.io registry
+        if: matrix.dockerfile == '13/Dockerfile.c9s' || matrix.dockerfile == '15/Dockerfile.c9s'
+        uses: sclorg/build-and-push-action@v4
+        with:
+          registry: "quay.io"
+          registry_namespace: ${{ matrix.registry_namespace }}
+          registry_username: ${{ secrets[matrix.quayio_username] }}
+          registry_token: ${{ secrets[matrix.quayio_token] }}
+          dockerfile: ${{ matrix.dockerfile }}
+          docker_context: ${{ matrix.docker_context }}
+          tag: ${{ matrix.tag }}
+          image_name: ${{ matrix.image_name }}
+          archs: amd64, s390x, ppc64le
+          
+      - name: Check if Dockerfile is not c9s, then Build and push to quay.io registry
+        if: matrix.dockerfile != '13/Dockerfile.c9s' && matrix.dockerfile != '15/Dockerfile.c9s'
         uses: sclorg/build-and-push-action@v4
         with:
           registry: "quay.io"


### PR DESCRIPTION
Multi arch image for postgres centos 9 based

Updated workflow for supporting multi arch postgres 13 & 15 image centos 9 based.

Verified the same by running github build & push action & validating image is getting multi-arch
https://github.com/modassarrana89/postgresql-container/actions
<img width="1768" alt="Screenshot 2023-05-22 at 3 36 07 PM" src="https://github.com/sclorg/postgresql-container/assets/119933819/c80f9e4e-d4e4-4cdd-ab9e-24527bf0b853">

