### PR TITLE
add pipefail to migrate_db function

### DIFF
--- a/10/root/usr/share/container-scripts/postgresql/common.sh
+++ b/10/root/usr/share/container-scripts/postgresql/common.sh
@@ -250,6 +250,7 @@ migrate_db ()
 
     # Migration path.
     (
+        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi

--- a/12/root/usr/share/container-scripts/postgresql/common.sh
+++ b/12/root/usr/share/container-scripts/postgresql/common.sh
@@ -250,6 +250,7 @@ migrate_db ()
 
     # Migration path.
     (
+        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi

--- a/13/root/usr/share/container-scripts/postgresql/common.sh
+++ b/13/root/usr/share/container-scripts/postgresql/common.sh
@@ -250,6 +250,7 @@ migrate_db ()
 
     # Migration path.
     (
+        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi

--- a/14/root/usr/share/container-scripts/postgresql/common.sh
+++ b/14/root/usr/share/container-scripts/postgresql/common.sh
@@ -250,6 +250,7 @@ migrate_db ()
 
     # Migration path.
     (
+        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi

--- a/15/root/usr/share/container-scripts/postgresql/common.sh
+++ b/15/root/usr/share/container-scripts/postgresql/common.sh
@@ -250,6 +250,7 @@ migrate_db ()
 
     # Migration path.
     (
+        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi

--- a/src/root/usr/share/container-scripts/postgresql/common.sh
+++ b/src/root/usr/share/container-scripts/postgresql/common.sh
@@ -251,6 +251,7 @@ migrate_db ()
 
     # Migration path.
     (
+        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi


### PR DESCRIPTION
Currently when the remote migration fails, the `grep` will catch the error and return status 0. This is unexpected behavior. Adding the `pipefail` will catch errors at any point in the pipe and fail the process.
