### PR TITLE
move pipefail outside of pg_dump block

### DIFF
--- a/10/root/usr/share/container-scripts/postgresql/common.sh
+++ b/10/root/usr/share/container-scripts/postgresql/common.sh
@@ -248,9 +248,9 @@ migrate_db ()
 {
     test "$postinitdb_actions" = ",migration" || return 0
 
+    set -o pipefail
     # Migration path.
     (
-        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi

--- a/12/root/usr/share/container-scripts/postgresql/common.sh
+++ b/12/root/usr/share/container-scripts/postgresql/common.sh
@@ -248,9 +248,9 @@ migrate_db ()
 {
     test "$postinitdb_actions" = ",migration" || return 0
 
+    set -o pipefail
     # Migration path.
     (
-        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi

--- a/13/root/usr/share/container-scripts/postgresql/common.sh
+++ b/13/root/usr/share/container-scripts/postgresql/common.sh
@@ -248,9 +248,9 @@ migrate_db ()
 {
     test "$postinitdb_actions" = ",migration" || return 0
 
+    set -o pipefail
     # Migration path.
     (
-        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi

--- a/14/root/usr/share/container-scripts/postgresql/common.sh
+++ b/14/root/usr/share/container-scripts/postgresql/common.sh
@@ -248,9 +248,9 @@ migrate_db ()
 {
     test "$postinitdb_actions" = ",migration" || return 0
 
+    set -o pipefail
     # Migration path.
     (
-        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi

--- a/15/root/usr/share/container-scripts/postgresql/common.sh
+++ b/15/root/usr/share/container-scripts/postgresql/common.sh
@@ -248,9 +248,9 @@ migrate_db ()
 {
     test "$postinitdb_actions" = ",migration" || return 0
 
+    set -o pipefail
     # Migration path.
     (
-        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi

--- a/src/root/usr/share/container-scripts/postgresql/common.sh
+++ b/src/root/usr/share/container-scripts/postgresql/common.sh
@@ -249,9 +249,9 @@ migrate_db ()
 {
     test "$postinitdb_actions" = ",migration" || return 0
 
+    set -o pipefail
     # Migration path.
     (
-        set -o pipefail
         if [ ${POSTGRESQL_MIGRATION_IGNORE_ERRORS-no} = no ]; then
             echo '\set ON_ERROR_STOP on'
         fi


### PR DESCRIPTION
The pipe fail needs to be moved outside of the parenthesis in order to catch all errors inside of the code block.
