### PR TITLE
Add ARM64 support to c9s images

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -119,7 +119,7 @@ jobs:
           docker_context: ${{ matrix.docker_context }}
           tag: ${{ matrix.tag }}
           image_name: ${{ matrix.image_name }}
-          archs: amd64, s390x, ppc64le
+          archs: amd64, s390x, ppc64le, arm64
           
       - name: Check if Dockerfile is not c9s, then Build and push to quay.io registry
         if: matrix.dockerfile != '13/Dockerfile.c9s' && matrix.dockerfile != '15/Dockerfile.c9s'


### PR DESCRIPTION
With ARM64 increasing market share, it makes sense to have native images for this platform too.

This also aligns it with RHEL version of these images, e.g. https://catalog.redhat.com/software/containers/rhel9/postgresql-15/63f763f779eb1214c4d6fcf6?architecture=arm64