### PR TITLE
Gracefully shut down the original container

### DIFF
--- a/test/run_test
+++ b/test/run_test
@@ -634,6 +634,13 @@ $volume_options
 
   echo "  Changing passwords"
 
+  echo "Kill the previous container and create a new one"
+  local cidfile=$CID_FILE_DIR/"${name}"
+  docker kill $(cat $cidfile)
+  docker rm -f $(cat $cidfile)
+  # Don't forget to remove its .cid file
+  rm $cidfile
+
   DOCKER_ARGS="
 -e POSTGRESQL_DATABASE=${database}
 -e POSTGRESQL_USER=${user}

--- a/test/run_test
+++ b/test/run_test
@@ -634,11 +634,6 @@ $volume_options
 
   echo "  Changing passwords"
 
-  # create separate mounting directory for second container, as selinux does
-  # not allow two containers accesing one mounting directory if mounted with
-  # Z option
-  create_volume_dir || ret=1
-
   DOCKER_ARGS="
 -e POSTGRESQL_DATABASE=${database}
 -e POSTGRESQL_USER=${user}


### PR DESCRIPTION
With keeping the container running, we see SELinux error messages and a sudden crash of the PostgreSQL container. Let's properly shut down the container before using its volume privately mounted into a different container.

This should fix #536 and also reverts previous attempt (#538) to fix the issues with SELinux messages.

Background:
podman's :Z modificator for volumes works the way that the latest container run with the same volume directory mounted with :Z modificator has access, the previous containers are kept running, but access to the shared directory is suddenly removed. That caused the first instance of PostgreSQL server to crash with SIGSEGV actually, while triggering some SELinux error message during that.

Related to #542.
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
