### PR TITLE
Remove dead link from this repo

### DIFF
--- a/10/Dockerfile.c8s
+++ b/10/Dockerfile.c8s
@@ -60,6 +60,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/10/Dockerfile.rhel7
+++ b/10/Dockerfile.rhel7
@@ -63,6 +63,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable
 # the SCL for all scripts without need to do 'scl enable'.

--- a/10/Dockerfile.rhel8
+++ b/10/Dockerfile.rhel8
@@ -61,6 +61,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/10/s2i/bin/run
+++ b/10/s2i/bin/run
@@ -1,1 +1,0 @@
-/usr/bin/run-postgresql

--- a/12/Dockerfile.c8s
+++ b/12/Dockerfile.c8s
@@ -61,6 +61,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/12/Dockerfile.fedora
+++ b/12/Dockerfile.fedora
@@ -62,6 +62,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 VOLUME ["/var/lib/pgsql/data"]
 
 # S2I permission fixes

--- a/12/Dockerfile.rhel7
+++ b/12/Dockerfile.rhel7
@@ -64,6 +64,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable
 # the SCL for all scripts without need to do 'scl enable'.

--- a/12/Dockerfile.rhel8
+++ b/12/Dockerfile.rhel8
@@ -62,6 +62,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/12/s2i/bin/run
+++ b/12/s2i/bin/run
@@ -1,1 +1,0 @@
-/usr/bin/run-postgresql

--- a/13/Dockerfile.c8s
+++ b/13/Dockerfile.c8s
@@ -61,6 +61,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/13/Dockerfile.c9s
+++ b/13/Dockerfile.c9s
@@ -60,6 +60,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/13/Dockerfile.fedora
+++ b/13/Dockerfile.fedora
@@ -62,6 +62,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 VOLUME ["/var/lib/pgsql/data"]
 
 # S2I permission fixes

--- a/13/Dockerfile.rhel7
+++ b/13/Dockerfile.rhel7
@@ -64,6 +64,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable
 # the SCL for all scripts without need to do 'scl enable'.

--- a/13/Dockerfile.rhel8
+++ b/13/Dockerfile.rhel8
@@ -62,6 +62,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/13/Dockerfile.rhel9
+++ b/13/Dockerfile.rhel9
@@ -62,6 +62,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/13/s2i/bin/run
+++ b/13/s2i/bin/run
@@ -1,1 +1,0 @@
-/usr/bin/run-postgresql

--- a/14/Dockerfile.fedora
+++ b/14/Dockerfile.fedora
@@ -62,6 +62,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 VOLUME ["/var/lib/pgsql/data"]
 
 # S2I permission fixes

--- a/14/s2i/bin/run
+++ b/14/s2i/bin/run
@@ -1,1 +1,0 @@
-/usr/bin/run-postgresql

--- a/15/Dockerfile.c8s
+++ b/15/Dockerfile.c8s
@@ -61,6 +61,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/15/Dockerfile.c9s
+++ b/15/Dockerfile.c9s
@@ -60,6 +60,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/15/Dockerfile.fedora
+++ b/15/Dockerfile.fedora
@@ -62,6 +62,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 VOLUME ["/var/lib/pgsql/data"]
 
 # S2I permission fixes

--- a/15/Dockerfile.rhel8
+++ b/15/Dockerfile.rhel8
@@ -62,6 +62,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/15/Dockerfile.rhel9
+++ b/15/Dockerfile.rhel9
@@ -62,6 +62,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/15/s2i/bin/run
+++ b/15/s2i/bin/run
@@ -1,1 +1,0 @@
-/usr/bin/run-postgresql

--- a/16/Dockerfile.c8s
+++ b/16/Dockerfile.c8s
@@ -61,6 +61,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/16/Dockerfile.c9s
+++ b/16/Dockerfile.c9s
@@ -60,6 +60,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/16/Dockerfile.fedora
+++ b/16/Dockerfile.fedora
@@ -61,6 +61,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 VOLUME ["/var/lib/pgsql/data"]
 
 # S2I permission fixes

--- a/16/Dockerfile.rhel8
+++ b/16/Dockerfile.rhel8
@@ -62,6 +62,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/16/Dockerfile.rhel9
+++ b/16/Dockerfile.rhel9
@@ -62,6 +62,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/var/lib/pgsql/data"]

--- a/16/s2i/bin/run
+++ b/16/s2i/bin/run
@@ -1,1 +1,0 @@
-/usr/bin/run-postgresql

--- a/manifest.yml
+++ b/manifest.yml
@@ -101,7 +101,3 @@ SYMLINK_RULES:
 
   - src: ../test
     dest: test
-
-  - src: /usr/bin/run-postgresql
-    dest: s2i/bin/run
-    check_symlink: false  # Disable check of dead symlinks

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -96,6 +96,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 {% if spec.prod != "rhel8" and spec.prod != "rhel9" and config.os.id != "fedora" and spec.prod != "c8s" and spec.prod != "c9s" %}
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/src/Dockerfile.fedora
+++ b/src/Dockerfile.fedora
@@ -77,6 +77,11 @@ ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql
 COPY root /
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
 VOLUME ["/var/lib/pgsql/data"]
 
 # S2I permission fixes

--- a/src/s2i/bin/run
+++ b/src/s2i/bin/run
@@ -1,1 +1,0 @@
-/usr/bin/run-postgresql


### PR DESCRIPTION
This pull request removes dead link from this upstream repository.

During the syncing source from upstream/GitLab repositories, the dead links are not sync bu
Testing Farm because security.
Therefore GitLab tests are failing because `run` script is missing.

Creating symlink in Dockerfile's solved this problem.
Wrapper is not needed like:
```
$ cat s2i/bin/run
#!/usr/bash

exec /usr/bin/run-postgresql "$@"
$
```
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
