### PR TITLE
The .pid file persists after shut down

### DIFF
--- a/10/root/usr/share/container-scripts/postgresql/common.sh
+++ b/10/root/usr/share/container-scripts/postgresql/common.sh
@@ -296,6 +296,11 @@ function wait_for_postgresql_master() {
 
 run_pgupgrade ()
 (
+  # Remove .pid file if the file persists after ugly shut down
+  if [ -f "$PGDATA/postmaster.pid" ] && ! pgrep -f "postgres" > /dev/null; then
+    rm -rf "$PGDATA/postmaster.pid"
+  fi
+
   optimized=false
   old_raw_version=${POSTGRESQL_PREV_VERSION//\./}
   new_raw_version=${POSTGRESQL_VERSION//\./}

--- a/12/root/usr/share/container-scripts/postgresql/common.sh
+++ b/12/root/usr/share/container-scripts/postgresql/common.sh
@@ -296,6 +296,11 @@ function wait_for_postgresql_master() {
 
 run_pgupgrade ()
 (
+  # Remove .pid file if the file persists after ugly shut down
+  if [ -f "$PGDATA/postmaster.pid" ] && ! pgrep -f "postgres" > /dev/null; then
+    rm -rf "$PGDATA/postmaster.pid"
+  fi
+
   optimized=false
   old_raw_version=${POSTGRESQL_PREV_VERSION//\./}
   new_raw_version=${POSTGRESQL_VERSION//\./}

--- a/13/root/usr/share/container-scripts/postgresql/common.sh
+++ b/13/root/usr/share/container-scripts/postgresql/common.sh
@@ -296,6 +296,11 @@ function wait_for_postgresql_master() {
 
 run_pgupgrade ()
 (
+  # Remove .pid file if the file persists after ugly shut down
+  if [ -f "$PGDATA/postmaster.pid" ] && ! pgrep -f "postgres" > /dev/null; then
+    rm -rf "$PGDATA/postmaster.pid"
+  fi
+
   optimized=false
   old_raw_version=${POSTGRESQL_PREV_VERSION//\./}
   new_raw_version=${POSTGRESQL_VERSION//\./}

--- a/14/root/usr/share/container-scripts/postgresql/common.sh
+++ b/14/root/usr/share/container-scripts/postgresql/common.sh
@@ -296,6 +296,11 @@ function wait_for_postgresql_master() {
 
 run_pgupgrade ()
 (
+  # Remove .pid file if the file persists after ugly shut down
+  if [ -f "$PGDATA/postmaster.pid" ] && ! pgrep -f "postgres" > /dev/null; then
+    rm -rf "$PGDATA/postmaster.pid"
+  fi
+
   optimized=false
   old_raw_version=${POSTGRESQL_PREV_VERSION//\./}
   new_raw_version=${POSTGRESQL_VERSION//\./}

--- a/15/root/usr/share/container-scripts/postgresql/common.sh
+++ b/15/root/usr/share/container-scripts/postgresql/common.sh
@@ -296,6 +296,11 @@ function wait_for_postgresql_master() {
 
 run_pgupgrade ()
 (
+  # Remove .pid file if the file persists after ugly shut down
+  if [ -f "$PGDATA/postmaster.pid" ] && ! pgrep -f "postgres" > /dev/null; then
+    rm -rf "$PGDATA/postmaster.pid"
+  fi
+
   optimized=false
   old_raw_version=${POSTGRESQL_PREV_VERSION//\./}
   new_raw_version=${POSTGRESQL_VERSION//\./}

--- a/16/root/usr/share/container-scripts/postgresql/common.sh
+++ b/16/root/usr/share/container-scripts/postgresql/common.sh
@@ -296,6 +296,11 @@ function wait_for_postgresql_master() {
 
 run_pgupgrade ()
 (
+  # Remove .pid file if the file persists after ugly shut down
+  if [ -f "$PGDATA/postmaster.pid" ] && ! pgrep -f "postgres" > /dev/null; then
+    rm -rf "$PGDATA/postmaster.pid"
+  fi
+
   optimized=false
   old_raw_version=${POSTGRESQL_PREV_VERSION//\./}
   new_raw_version=${POSTGRESQL_VERSION//\./}

--- a/src/root/usr/share/container-scripts/postgresql/common.sh
+++ b/src/root/usr/share/container-scripts/postgresql/common.sh
@@ -297,6 +297,11 @@ function wait_for_postgresql_master() {
 
 run_pgupgrade ()
 (
+  # Remove .pid file if the file persists after ugly shut down
+  if [ -f "$PGDATA/postmaster.pid" ] && ! pgrep -f "postgres" > /dev/null; then
+    rm -rf "$PGDATA/postmaster.pid"
+  fi
+
   optimized=false
   old_raw_version=${POSTGRESQL_PREV_VERSION//\./}
   new_raw_version=${POSTGRESQL_VERSION//\./}


### PR DESCRIPTION
.pid is present during postgresql-server run. It should be removed with server stop. in some circumstances, it persists after the container shuts down. If it happens, this check should ensure the state is correct before the upgrade. It should remove the redundant file.

