### PR TITLE
chore: fix readme typo

### DIFF
--- a/examples/enable-ssl/README.md
+++ b/examples/enable-ssl/README.md
@@ -23,8 +23,8 @@ oc new-app --name psql-ssl postgresql:13-el7~https://github.com/sclorg/postgresq
 
 ```bash
 openssl genrsa -out tls.key 2048
-openssl req -new -x509 -key tls.key -out tls.cert
-oc create secret tls db-ssl-keys --key tls.key --cert tls.cert
+openssl req -new -x509 -key tls.key -out tls.crt
+oc create secret tls db-ssl-keys --key tls.key --cert tls.crt
 ```
 
 3. Bind your secrets into postgres deploymentConfig:


### PR DESCRIPTION

In the readme,  **tls.cert** is being used, but in the configuration file tls.crt is defined ( ssl_cert_file = '/opt/app-root/src/certs/tls.crt').

This simple mistake can easily cause someone to lose time if they don't pay attention.