### PR TITLE
Add file show_all_imagestreams.py from container-common-scripts

### DIFF
--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -22,7 +22,7 @@
         app_versions: [10, 12, 13]
 
       - name: RHEL 8
-        app_versions: [10, 12, 13, 15]
+        app_versions: [10, 12, 13, 15, 16]
 
       - name: RHEL 9
         app_versions: [13, 15, 16]
@@ -31,7 +31,7 @@
     latest: "16-el9"
     distros:
       - name: RHEL 8
-        app_versions: [10, 12, 13, 15]
+        app_versions: [10, 12, 13, 15, 16]
 
       - name: RHEL 9
         app_versions: [13, 15, 16]

--- a/imagestreams/postgresql-rhel-aarch64.json
+++ b/imagestreams/postgresql-rhel-aarch64.json
@@ -82,6 +82,24 @@
         }
       },
       {
+        "name": "16-el8",
+        "annotations": {
+          "openshift.io/display-name": "PostgreSQL 16 (RHEL 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a PostgreSQL 16 database on RHEL 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+          "iconClass": "icon-postgresql",
+          "tags": "database,postgresql",
+          "version": "16"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhel8/postgresql-16:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "13-el9",
         "annotations": {
           "openshift.io/display-name": "PostgreSQL 13 (RHEL 9)",

--- a/imagestreams/postgresql-rhel.json
+++ b/imagestreams/postgresql-rhel.json
@@ -136,6 +136,24 @@
         }
       },
       {
+        "name": "16-el8",
+        "annotations": {
+          "openshift.io/display-name": "PostgreSQL 16 (RHEL 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a PostgreSQL 16 database on RHEL 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+          "iconClass": "icon-postgresql",
+          "tags": "database,postgresql",
+          "version": "16"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhel8/postgresql-16:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "13-el9",
         "annotations": {
           "openshift.io/display-name": "PostgreSQL 13 (RHEL 9)",

--- a/test/show_all_imagestreams.py
+++ b/test/show_all_imagestreams.py
@@ -1,0 +1,1 @@
+../common/show_all_imagestreams.py


### PR DESCRIPTION
This pull request only adds show_all_imagestreams.py so it is working.

The file `show_all_imagestreams.py` shows all available imagestreams for this container, that are specified
in the directory `imagestreams`.

The example output will be seen in the next comment.
