### PR TITLE
Add support for testing postgresql container in C10S

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "11", "12", "13", "14", "15", "16" ]
-        os_test: [ "fedora", "rhel8", "rhel9", "c9s" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s" ]
         test_case: [ "container" ]
 
     if: |


### PR DESCRIPTION
This pull request enables testing postgresql-container in C10S.

Not running tests are needed.
