### PR TITLE
Support for building and testing PSQL-16 on C10S replace nss-wrapper with nss-wrapper-libs

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -38,6 +38,14 @@ jobs:
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
             docker_context: 16
 
+          - dockerfile: "16/Dockerfile.c10s"
+            registry_namespace: "sclorg"
+            tag: "c10s"
+            image_name: "postgresql-16-c10s"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+            docker_context: 16
+
           - dockerfile: "15/Dockerfile.fedora"
             registry_namespace: "fedora"
             tag: "15"

--- a/12/Dockerfile.rhel8
+++ b/12/Dockerfile.rhel8
@@ -43,7 +43,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum -y module enable postgresql:12 && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/13/Dockerfile.c9s
+++ b/13/Dockerfile.c9s
@@ -42,7 +42,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN  { yum -y module enable postgresql:13 || :; } && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/13/Dockerfile.rhel8
+++ b/13/Dockerfile.rhel8
@@ -43,7 +43,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum -y module enable postgresql:13 && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/13/Dockerfile.rhel9
+++ b/13/Dockerfile.rhel9
@@ -43,7 +43,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN { yum -y module enable postgresql:13 || :; } && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/15/Dockerfile.c9s
+++ b/15/Dockerfile.c9s
@@ -42,7 +42,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN  { yum -y module enable postgresql:15 || :; } && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/15/Dockerfile.rhel8
+++ b/15/Dockerfile.rhel8
@@ -43,7 +43,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum -y module enable postgresql:15 && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/15/Dockerfile.rhel9
+++ b/15/Dockerfile.rhel9
@@ -43,7 +43,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN { yum -y module enable postgresql:15 || :; } && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/16/Dockerfile.c10s
+++ b/16/Dockerfile.c10s
@@ -51,7 +51,8 @@ RUN INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server pos
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
     mkdir -p /var/lib/pgsql/data && \
-    /usr/libexec/fix-permissions /var/lib/pgsql /var/run/postgresql
+    # Directory /var/run/postgresql was removed and /run/postgresql is marked as %ghost dir
+    /usr/libexec/fix-permissions /var/lib/pgsql
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \

--- a/16/Dockerfile.c10s
+++ b/16/Dockerfile.c10s
@@ -51,8 +51,8 @@ RUN INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server pos
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
     mkdir -p /var/lib/pgsql/data && \
-    # Directory /var/run/postgresql was removed and /run/postgresql is marked as %ghost dir
-    /usr/libexec/fix-permissions /var/lib/pgsql
+    mkdir -p /run/postgresql && \
+    /usr/libexec/fix-permissions /var/lib/pgsql /run/postgresql
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \

--- a/16/Dockerfile.c10s
+++ b/16/Dockerfile.c10s
@@ -41,7 +41,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs postgresql-server postgresql-contrib glibc-locale-source" && \
+RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs postgresql-server postgresql-contrib glibc-locale-source xz" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/16/Dockerfile.c10s
+++ b/16/Dockerfile.c10s
@@ -1,0 +1,89 @@
+FROM quay.io/sclorg/s2i-core-c10s:c10s
+
+# PostgreSQL image for OpenShift.
+# Volumes:
+#  * /var/lib/pgsql/data   - Database cluster for PostgreSQL
+# Environment:
+#  * $POSTGRESQL_USER     - Database user name
+#  * $POSTGRESQL_PASSWORD - User's password
+#  * $POSTGRESQL_DATABASE - Name of the database to create
+#  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
+#                           PostgreSQL administrative account
+
+ENV POSTGRESQL_VERSION=16 \
+    POSTGRESQL_PREV_VERSION=15 \
+    HOME=/var/lib/pgsql \
+    PGUSER=postgres \
+    APP_DATA=/opt/app-root
+
+ENV SUMMARY="PostgreSQL is an advanced Object-Relational database management system" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
+The image contains the client and server programs that you'll need to \
+create, run, maintain and access a PostgreSQL DBMS server."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="PostgreSQL 16" \
+      io.openshift.expose-services="5432:postgresql" \
+      io.openshift.tags="database,postgresql,postgresql16,postgresql-16" \
+      io.openshift.s2i.assemble-user="26" \
+      name="sclorg/postgresql-16-c10s" \
+      com.redhat.component="postgresql-16-container" \
+      version="1" \
+      usage="podman run -d --name postgresql_database -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -p 5432:5432 sclorg/postgresql-16-c10s" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 5432
+
+COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
+
+# This image must forever use UID 26 for postgres user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib glibc-locale-source" && \
+    INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
+    INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
+    yum -y clean all --enablerepo='*' && \
+    localedef -f UTF-8 -i en_US en_US.UTF-8 && \
+    test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
+    mkdir -p /var/lib/pgsql/data && \
+    /usr/libexec/fix-permissions /var/lib/pgsql /var/run/postgresql
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
+    ENABLED_COLLECTIONS=
+
+COPY root /
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/var/lib/pgsql/data"]
+
+# S2I permission fixes
+# --------------------
+# 1. unless specified otherwise (or - equivalently - we are in OpenShift), s2i
+#    build process would be executed as 'uid=26(postgres) gid=26(postgres)'.
+#    Such process wouldn't be able to execute the default 'assemble' script
+#    correctly (it transitively executes 'fix-permissions' script).  So let's
+#    add the 'postgres' user into 'root' group here
+#
+# 2. we call fix-permissions on $APP_DATA here directly (UID=0 during build
+#    anyways) to assure that s2i process is actually able to _read_ the
+#    user-specified scripting.
+RUN usermod -a -G root postgres && \
+    /usr/libexec/fix-permissions --read-only "$APP_DATA"
+
+USER 26
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-postgresql"]

--- a/16/Dockerfile.c10s
+++ b/16/Dockerfile.c10s
@@ -41,7 +41,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib glibc-locale-source" && \
+RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs postgresql-server postgresql-contrib glibc-locale-source" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/16/Dockerfile.c10s
+++ b/16/Dockerfile.c10s
@@ -41,12 +41,11 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs postgresql16-server postgresql16-contrib glibc-locale-source xz" && \
-    PSQL_PKGS=postgresql16-server postgresql16-contrib glibc-locale-source xz && \
+RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs glibc-locale-source xz" && \
+    PSQL_PKGS="postgresql16-server postgresql16-contrib postgresql16-upgrade" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
-    INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS $PSQL_PKGS  && \
-    rpm -V $INSTALL_PKGS postgresql-server-16 postgresql-contrib-16 && \
+    rpm -V $INSTALL_PKGS postgresql-server postgresql-contrib postgresql-upgrade && \
     postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/16/Dockerfile.c10s
+++ b/16/Dockerfile.c10s
@@ -41,11 +41,12 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs postgresql-server postgresql-contrib glibc-locale-source xz" && \
+RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs postgresql16-server postgresql16-contrib glibc-locale-source xz" && \
+    PSQL_PKGS=postgresql16-server postgresql16-contrib glibc-locale-source xz && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
-    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS $PSQL_PKGS  && \
+    rpm -V $INSTALL_PKGS postgresql-server-16 postgresql-contrib-16 && \
     postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/16/Dockerfile.c9s
+++ b/16/Dockerfile.c9s
@@ -42,7 +42,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN  { yum -y module enable postgresql:16 || :; } && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/16/Dockerfile.rhel8
+++ b/16/Dockerfile.rhel8
@@ -43,7 +43,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum -y module enable postgresql:16 && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/16/Dockerfile.rhel9
+++ b/16/Dockerfile.rhel9
@@ -43,7 +43,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN { yum -y module enable postgresql:16 || :; } && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -15,6 +15,9 @@
       - name: CentOS Stream 9
         app_versions: [13, 15, 16]
 
+      - name: CentOS Stream 10
+        app_versions: [16]
+
   - filename: postgresql-rhel.json
     latest: "16-el9"
     distros:

--- a/imagestreams/postgresql-centos.json
+++ b/imagestreams/postgresql-centos.json
@@ -64,6 +64,24 @@
         }
       },
       {
+        "name": "16-el10",
+        "annotations": {
+          "openshift.io/display-name": "PostgreSQL 16 (CentOS Stream 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a PostgreSQL 16 database on CentOS Stream 10. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+          "iconClass": "icon-postgresql",
+          "tags": "database,postgresql",
+          "version": "16"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/sclorg/postgresql-16-c10s:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "latest",
         "annotations": {
           "openshift.io/display-name": "PostgreSQL 16 (Latest)",

--- a/manifest.yml
+++ b/manifest.yml
@@ -32,6 +32,9 @@ DISTGEN_MULTI_RULES:
   - src: src/Dockerfile
     dest: Dockerfile.c9s
 
+  - src: src/Dockerfile
+    dest: Dockerfile.c10s
+
   - src: src/Dockerfile.fedora
     dest: Dockerfile.fedora
 

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -74,7 +74,8 @@ specs:
       openshift_tags: "database,postgresql,postgresql{{ spec.short }},postgresql-{{ spec.short }}"
       redhat_component: "postgresql-{{ spec.short }}-container"
       img_name: "{{ spec.org }}/postgresql-{{ spec.short }}-{{ spec.prod }}"
-      pkgs: "postgresql-server postgresql-contrib glibc-locale-source xz"
+      pkgs: "postgresql{{ spec.short }}-server postgresql{{ spec.short }}-contrib glibc-locale-source xz"
+      check_pkgs: "postgresql-server-{{ spec.short }} postgresql-contrib-{{ spec.short }}"
 
   version:
     "12":

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -74,7 +74,7 @@ specs:
       openshift_tags: "database,postgresql,postgresql{{ spec.short }},postgresql-{{ spec.short }}"
       redhat_component: "postgresql-{{ spec.short }}-container"
       img_name: "{{ spec.org }}/postgresql-{{ spec.short }}-{{ spec.prod }}"
-      pkgs: "postgresql-server postgresql-contrib glibc-locale-source"
+      pkgs: "postgresql-server postgresql-contrib glibc-locale-source xz"
 
   version:
     "12":

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -74,8 +74,8 @@ specs:
       openshift_tags: "database,postgresql,postgresql{{ spec.short }},postgresql-{{ spec.short }}"
       redhat_component: "postgresql-{{ spec.short }}-container"
       img_name: "{{ spec.org }}/postgresql-{{ spec.short }}-{{ spec.prod }}"
-      pkgs: "postgresql{{ spec.short }}-server postgresql{{ spec.short }}-contrib glibc-locale-source xz"
-      check_pkgs: "postgresql-server-{{ spec.short }} postgresql-contrib-{{ spec.short }}"
+      pkgs: "postgresql{{ spec.short }}-server postgresql{{ spec.short }}-contrib postgresql{{ spec.short }}-upgrade"
+      check_pkgs: "postgresql-server postgresql-contrib postgresql-upgrade"
 
   version:
     "12":

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -65,6 +65,17 @@ specs:
       environment_setup: >-4
            { yum -y module enable postgresql:{{ spec.version }} || :; } && \
 
+    c10s:
+      distros:
+        - centos-stream-10-x86_64
+      s2i_base: quay.io/sclorg/s2i-core-c10s:c10s
+      org: "sclorg"
+      prod: "c10s"
+      openshift_tags: "database,postgresql,postgresql{{ spec.short }},postgresql-{{ spec.short }}"
+      redhat_component: "postgresql-{{ spec.short }}-container"
+      img_name: "{{ spec.org }}/postgresql-{{ spec.short }}-{{ spec.prod }}"
+      pkgs: "postgresql-server postgresql-contrib glibc-locale-source"
+
   version:
     "12":
       version: "12"
@@ -126,3 +137,4 @@ matrix:
         - rhel-9-x86_64
         - centos-stream-9-x86_64
         - fedora-40-x86_64
+        - centos-stream-10-x86_64

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -56,20 +56,10 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 {{ spec.repo_enable_reason }}
 {% endif %}
 {% if spec.prod == "c10s" %}
-RUN INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper {{ spec.pkgs }}" && \
+RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs {{ spec.pkgs }}" && \
 {% else %}
 RUN {{ spec.environment_setup }}
-{% if spec.has_devel_repo %}
-  {% if config.os.id == 'rhel' %}
-    {% if spec.has_devel_repo.rhel == 'brew' %}
-    yum-config-manager --add-repo http://download.devel.redhat.com/brewroot/repos/rhscl-{{ spec.rhscl_version.development }}-rh-postgresql{{ spec.version }}-rhel-7-build/latest/x86_64 && \
-    echo gpgcheck=0 >> /etc/yum.repos.d/download.devel.redhat.com_brewroot_repos_rhscl-{{ spec.rhscl_version.development }}-rh-postgresql{{ spec.version }}-rhel-7-build_latest_x86_64.repo && \
-    {% elif spec.has_devel_repo.rhel == 'beta' %}
-    yum-config-manager --enable rhel-server-rhscl-7-beta-rpms && \
-    {% endif %}
-  {% endif %}
-{% endif %}
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper {{ spec.pkgs }}" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs {{ spec.pkgs }}" && \
 {% endif %}
 {% if spec.version not in ["9.6", "10", "11"] %}
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -56,15 +56,17 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 {{ spec.repo_enable_reason }}
 {% endif %}
 {% if spec.prod == "c10s" %}
-RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs {{ spec.pkgs }}" && \
-    PSQL_PKGS={{ spec.pkgs }} && \
+RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs glibc-locale-source xz" && \
+    PSQL_PKGS="{{ spec.pkgs }}" && \
 {% else %}
 RUN {{ spec.environment_setup }}
     INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs {{ spec.pkgs }}" && \
 {% endif %}
 {% if spec.version not in ["9.6", "10", "11"] %}
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
+    {% if spec.prod != "c10s" %}
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
+    {% endif %}
 {% endif %}
 {% if spec.prod == "c10s" %}
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS $PSQL_PKGS  && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -57,6 +57,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 {% endif %}
 {% if spec.prod == "c10s" %}
 RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs {{ spec.pkgs }}" && \
+    PSQL_PKGS={{ spec.pkgs }} && \
 {% else %}
 RUN {{ spec.environment_setup }}
     INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs {{ spec.pkgs }}" && \
@@ -65,8 +66,13 @@ RUN {{ spec.environment_setup }}
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
 {% endif %}
+{% if spec.prod == "c10s" %}
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS $PSQL_PKGS  && \
+    rpm -V $INSTALL_PKGS {{ spec.check_pkgs }} && \
+{% else %}
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+{% endif %}
     postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
     {% if spec.post_install %}
     {{ spec.post_install }}

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -55,6 +55,9 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 {% if spec.repo_enable_reason %}
 {{ spec.repo_enable_reason }}
 {% endif %}
+{% if spec.prod == "c10s" %}
+RUN INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper {{ spec.pkgs }}" && \
+{% else %}
 RUN {{ spec.environment_setup }}
 {% if spec.has_devel_repo %}
   {% if config.os.id == 'rhel' %}
@@ -67,6 +70,7 @@ RUN {{ spec.environment_setup }}
   {% endif %}
 {% endif %}
     INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper {{ spec.pkgs }}" && \
+{% endif %}
 {% if spec.version not in ["9.6", "10", "11"] %}
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \

--- a/test/pg-test-lib.sh
+++ b/test/pg-test-lib.sh
@@ -33,6 +33,10 @@ get_image_id ()
                 ns=c9s
                 local image=quay.io/sclorg/postgresql-${version}-$ns
                 ;;
+            c10s)
+                ns=c10s
+                local image=quay.io/sclorg/postgresql-${version}-$ns
+                ;;
             esac
             docker pull "$image" >/dev/null
             echo "$image"


### PR DESCRIPTION
This pull request allows to build and test PSQL-16 on C10S

The pull request is separated into more commits:
* Update dist-gen sources
* dist-gen generated sources
* update imagestreams for C10S
* update build and push with postgresql-16-c10s
* Do not fix /run/postgresql and even /var/run/postgresql dirs. The first one is %ghost directory and the second one does not exist