### PR TITLE
Add Helm chart tests for PSQL

### DIFF
--- a/test/run-openshift-pytest
+++ b/test/run-openshift-pytest
@@ -10,4 +10,4 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 git show -s
 
-cd "${THISDIR}" && python3.12 -m pytest -s -rA --showlocals -vv test_postgresql_*.py
+cd "${THISDIR}" && python3.12 -m pytest -s -rA --showlocals -vv test_*.py

--- a/test/test_helm_postgresql_imagestreams.py
+++ b/test/test_helm_postgresql_imagestreams.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+import pytest
+
+from pathlib import Path
+
+from container_ci_suite.helm import HelmChartsAPI
+from container_ci_suite.utils import check_variables
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, VERSION is missing.")
+    sys.exit(1)
+
+test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
+
+
+class TestHelmRHELPostgresqlImageStreams:
+
+    def setup_method(self):
+        package_name = "postgresql-imagestreams"
+        path = test_dir
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api.clone_helm_chart_repo(
+            repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
+            subdir="charts/redhat"
+        )
+
+    def teardown_method(self):
+        self.hc_api.delete_project()
+
+    @pytest.mark.parametrize(
+        "version,registry,expected",
+        [
+            ("10-el8", "registry.redhat.io/rhel8/postgresql-10:latest", False),
+            ("13-el8", "registry.redhat.io/rhel8/postgresql-13:latest", True),
+            ("13-el9", "registry.redhat.io/rhel9/postgresql-13:latest", True),
+            ("15-el8", "registry.redhat.io/rhel8/postgresql-15:latest", True),
+            ("15-el9", "registry.redhat.io/rhel9/postgresql-15:latest", True),
+            ("16-el8", "registry.redhat.io/rhel8/postgresql-16:latest", True),
+            ("16-el9", "registry.redhat.io/rhel9/postgresql-16:latest", True),
+        ],
+    )
+    def test_package_imagestream(self, version, registry, expected):
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
+        assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/test/test_helm_postgresql_template.py
+++ b/test/test_helm_postgresql_template.py
@@ -1,0 +1,56 @@
+import os
+import sys
+
+import pytest
+
+from pathlib import Path
+
+from container_ci_suite.helm import HelmChartsAPI
+from container_ci_suite.utils import check_variables
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, VERSION is missing.")
+    sys.exit(1)
+
+test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
+
+
+VERSION = os.getenv("VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("TARGET")
+
+TAGS = {
+    "rhel8": "-el8",
+    "rhel9": "-el9"
+}
+TAG = TAGS.get(OS, None)
+
+
+class TestHelmPostgresqlPersistent:
+
+    def setup_method(self):
+        package_name = "postgresql-persistent"
+        path = test_dir
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api.clone_helm_chart_repo(
+            repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
+            subdir="charts/redhat"
+        )
+
+    def teardown_method(self):
+        self.hc_api.delete_project()
+
+    def test_package_persistent(self):
+        self.hc_api.package_name = "postgresql-imagestreams"
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
+        self.hc_api.package_name = "postgresql-persistent"
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation(
+            values={
+                ".image.tag": f"{VERSION}{TAG}",
+                ".namespace": self.hc_api.namespace
+            }
+        )
+        assert self.hc_api.is_pod_running(pod_name_prefix="postgresql-persistent")
+        assert self.hc_api.test_helm_chart(expected_str=["accepting connection"])


### PR DESCRIPTION
Add Helm chart tests for PSQL

We need to test if helm charts work in postgresql container

In OpenShift we deliver helmcharts and we need to test them by each pull request.