### PR TITLE
remove module postgresql-13 on RHEL9

### DIFF
--- a/13/Dockerfile.rhel9
+++ b/13/Dockerfile.rhel9
@@ -42,8 +42,8 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN { yum -y module enable postgresql:13 || :; } && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
+ \
+RUN INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -58,6 +58,8 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 {% if spec.prod == "c10s" %}
 RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs glibc-locale-source xz" && \
     PSQL_PKGS="{{ spec.pkgs }}" && \
+{% elif spec.prod == "rhel9" and spec.version == "13" %} \
+RUN INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs {{ spec.pkgs }}" && \
 {% else %}
 RUN {{ spec.environment_setup }}
     INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs {{ spec.pkgs }}" && \


### PR DESCRIPTION
This pull request removes module postgresql-13 on RHEL9.
Module does not exist. Only RPMs are available.