### PR TITLE
Fix error in `run_pgaudit_test()`

### DIFF
--- a/test/run_test
+++ b/test/run_test
@@ -934,7 +934,7 @@ run_pgaudit_test()
   # create a dir for config
   config_dir=$(mktemp -d --tmpdir pg-hook-volume.XXXXX)
   add_cleanup_command /bin/rm -rf "$config_dir"
-  -v DOCKER_EXTRA_ARGS || cp -r "$test_dir"/examples/pgaudit/* "$config_dir"
+  test -n "$DOCKER_EXTRA_ARGS" || cp -r "$test_dir"/examples/pgaudit/* "$config_dir"
   setfacl -R -m u:26:rwx "$config_dir"
 
   # create a dir for data


### PR DESCRIPTION
Initially command `test was missing`, but after it was added test failed and crashed in a way that no more tests were run. This behavior is known issue tracked here in issue #537

Problem is that `DOCKER_EXTRA_ARGS` variable is set already which it shouldn't be, so the `test` command returns 0, so no `cp` happens and we get the crash.

Variable is empty, but apparently do exist as
`test -v DOCKER_EXTRA_ARGS` is `TRUE`.

Introduced by PR #399

Fixes: #595











































































<!-- testing-farm = {"lock":"false","comment-id":"2400100670","data":[{"id":"69bfa6cd-8864-4888-a7c3-4f0da96d40d5","name":"CentOS Stream 10 - 16","status":"complete","outcome":"passed","runTime":461.475624,"created":"2024-10-08T14:53:27.881165","updated":"2024-10-08T14:53:27.881173","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/69bfa6cd-8864-4888-a7c3-4f0da96d40d5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/69bfa6cd-8864-4888-a7c3-4f0da96d40d5/pipeline.log\">pipeline</a>"]},{"id":"12a4e6a8-177f-4b16-967e-34432748864b","name":"Fedora - 16","status":"complete","outcome":"passed","runTime":598.218669,"created":"2024-10-08T14:53:32.956479","updated":"2024-10-08T14:53:32.956487","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/12a4e6a8-177f-4b16-967e-34432748864b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/12a4e6a8-177f-4b16-967e-34432748864b/pipeline.log\">pipeline</a>"]},{"id":"8cc7a044-85d0-4fb3-b898-43cf9010b786","name":"CentOS Stream 9 - 13","status":"complete","outcome":"passed","runTime":611.402841,"created":"2024-10-08T14:53:15.434922","updated":"2024-10-08T14:53:15.434931","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8cc7a044-85d0-4fb3-b898-43cf9010b786\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8cc7a044-85d0-4fb3-b898-43cf9010b786/pipeline.log\">pipeline</a>"]},{"id":"2e3790a1-b983-499a-834b-5f0f8ee2524d","name":"CentOS Stream 9 - 15","status":"complete","outcome":"passed","runTime":713.732909,"created":"2024-10-08T14:53:30.182254","updated":"2024-10-08T14:53:30.182262","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2e3790a1-b983-499a-834b-5f0f8ee2524d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2e3790a1-b983-499a-834b-5f0f8ee2524d/pipeline.log\">pipeline</a>"]},{"id":"8f49cd95-afd9-4b56-b361-84ac3dcac500","name":"Fedora - 15","status":"complete","outcome":"passed","runTime":694.79716,"created":"2024-10-08T14:53:26.890406","updated":"2024-10-08T14:53:26.890413","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8f49cd95-afd9-4b56-b361-84ac3dcac500\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8f49cd95-afd9-4b56-b361-84ac3dcac500/pipeline.log\">pipeline</a>"]},{"id":"4da06d0b-fee0-48fd-9ee5-f070a12b2d88","name":"CentOS Stream 9 - 16","status":"complete","outcome":"passed","runTime":711.307439,"created":"2024-10-08T14:53:30.574456","updated":"2024-10-08T14:53:30.574467","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4da06d0b-fee0-48fd-9ee5-f070a12b2d88\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4da06d0b-fee0-48fd-9ee5-f070a12b2d88/pipeline.log\">pipeline</a>"]},{"id":"2a994044-324c-44e5-abcd-293c6140085f","name":"RHEL9 - 13","status":"complete","outcome":"passed","runTime":867.286664,"created":"2024-10-08T14:53:16.227698","updated":"2024-10-08T14:53:16.227706","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a994044-324c-44e5-abcd-293c6140085f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a994044-324c-44e5-abcd-293c6140085f/pipeline.log\">pipeline</a>"]},{"id":"7872d8e3-b2c8-4a0d-8b16-98d07a356a1b","name":"RHEL9 - 15","status":"complete","outcome":"passed","runTime":1021.517315,"created":"2024-10-08T14:53:26.405579","updated":"2024-10-08T14:53:26.405586","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7872d8e3-b2c8-4a0d-8b16-98d07a356a1b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7872d8e3-b2c8-4a0d-8b16-98d07a356a1b/pipeline.log\">pipeline</a>"]},{"id":"7ce84f69-4e9d-4320-8b53-03b620ccb3ab","name":"RHEL9 - 16","status":"complete","outcome":"passed","runTime":1061.483746,"created":"2024-10-08T14:53:28.776727","updated":"2024-10-08T14:53:28.776735","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ce84f69-4e9d-4320-8b53-03b620ccb3ab\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ce84f69-4e9d-4320-8b53-03b620ccb3ab/pipeline.log\">pipeline</a>"]},{"id":"2a77876e-fd50-4e66-bd06-a308847f4bd2","name":"RHEL8 - 12","status":"complete","outcome":"passed","runTime":1124.168922,"created":"2024-10-08T14:53:17.042681","updated":"2024-10-08T14:53:17.042689","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a77876e-fd50-4e66-bd06-a308847f4bd2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a77876e-fd50-4e66-bd06-a308847f4bd2/pipeline.log\">pipeline</a>"]},{"id":"8f5bb702-efec-42c8-bf5c-a140e735e480","name":"RHEL8 - 13","status":"complete","outcome":"passed","runTime":1208.684231,"created":"2024-10-08T14:53:17.558740","updated":"2024-10-08T14:53:17.558751","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8f5bb702-efec-42c8-bf5c-a140e735e480\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8f5bb702-efec-42c8-bf5c-a140e735e480/pipeline.log\">pipeline</a>"]},{"id":"8499624d-7c6a-4a90-b8c0-f8256edfbe00","name":"RHEL8 - 15","status":"complete","outcome":"passed","runTime":1220.928057,"created":"2024-10-08T14:53:27.769879","updated":"2024-10-08T14:53:27.769890","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8499624d-7c6a-4a90-b8c0-f8256edfbe00\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8499624d-7c6a-4a90-b8c0-f8256edfbe00/pipeline.log\">pipeline</a>"]},{"id":"f174c11d-22f5-417c-8176-55c0ee745076","name":"RHEL8 - 16","runTime":1361.216467,"created":"2024-10-08T14:53:27.221982","updated":"2024-10-08T14:53:27.221993","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f174c11d-22f5-417c-8176-55c0ee745076\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f174c11d-22f5-417c-8176-55c0ee745076/pipeline.log\">pipeline</a>"]}]} -->