### PR TITLE
Disable tests depending on  help.1 file presence

### DIFF
--- a/test/run_test
+++ b/test/run_test
@@ -20,7 +20,6 @@ run_container_creation_tests
 run_general_tests
 run_change_password_test
 run_replication_test
-run_doc_test
 run_s2i_test
 run_test_cfg_hook
 run_s2i_bake_data_test
@@ -805,9 +804,6 @@ ${mount_opts}
 run_s2i_test() {
   local temp_file
   local ret=0
-  echo "  Testing s2i usage"
-  ct_s2i_usage "${IMAGE_NAME}" --pull-policy=never 1>/dev/null || ret=1
-
   echo "  Testing s2i build"
 
   local s2i_image_name=$IMAGE_NAME-testapp_$(ct_random_string)


### PR DESCRIPTION
This file will no longer be included in images produced by Konflux, thus we shouldn't test it.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->














































































<!-- testing-farm = {"lock":"false","comment-id":"2422333452","data":[{"id":"8267abf8-366f-48c5-9e21-b3c3e1026070","name":"CentOS Stream 9 - 13","status":"complete","outcome":"passed","runTime":601.676305,"created":"2024-10-18T12:03:13.677619","updated":"2024-10-18T12:03:13.677629","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8267abf8-366f-48c5-9e21-b3c3e1026070\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8267abf8-366f-48c5-9e21-b3c3e1026070/pipeline.log\">pipeline</a>"]},{"id":"37bc789b-02c6-43fe-a5ae-533e7d9379b2","name":"CentOS Stream 10 - 16","status":"complete","outcome":"passed","runTime":605.072844,"created":"2024-10-18T12:03:34.645937","updated":"2024-10-18T12:03:34.645946","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/37bc789b-02c6-43fe-a5ae-533e7d9379b2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/37bc789b-02c6-43fe-a5ae-533e7d9379b2/pipeline.log\">pipeline</a>"]},{"id":"9f260ab9-f8e9-4f6b-969c-9be8099a177b","name":"CentOS Stream 9 - 15","status":"complete","outcome":"passed","runTime":685.768258,"created":"2024-10-18T12:03:26.800696","updated":"2024-10-18T12:03:26.800705","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9f260ab9-f8e9-4f6b-969c-9be8099a177b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9f260ab9-f8e9-4f6b-969c-9be8099a177b/pipeline.log\">pipeline</a>"]},{"id":"61e4a1f8-5ab6-4525-a34c-f95f901fcb7e","name":"CentOS Stream 9 - 16","status":"complete","outcome":"passed","runTime":670.207887,"created":"2024-10-18T12:03:34.864432","updated":"2024-10-18T12:03:34.864439","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/61e4a1f8-5ab6-4525-a34c-f95f901fcb7e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/61e4a1f8-5ab6-4525-a34c-f95f901fcb7e/pipeline.log\">pipeline</a>"]},{"id":"d398e1fb-0100-4636-bfe5-5b6c37dd8439","name":"Fedora - 15","status":"complete","outcome":"passed","runTime":869.164506,"created":"2024-10-18T12:03:30.178680","updated":"2024-10-18T12:03:30.178690","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d398e1fb-0100-4636-bfe5-5b6c37dd8439\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d398e1fb-0100-4636-bfe5-5b6c37dd8439/pipeline.log\">pipeline</a>"]},{"id":"bae4c65e-1f70-4a05-b05f-8512ee2c19b7","name":"Fedora - 16","status":"complete","outcome":"passed","runTime":859.424076,"created":"2024-10-18T12:03:42.677707","updated":"2024-10-18T12:03:42.677715","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bae4c65e-1f70-4a05-b05f-8512ee2c19b7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bae4c65e-1f70-4a05-b05f-8512ee2c19b7/pipeline.log\">pipeline</a>"]},{"id":"42890aec-3b82-47fa-9745-f726c41cfa8e","name":"RHEL9 - 13","status":"complete","outcome":"passed","runTime":1526.201462,"created":"2024-10-18T12:03:17.797171","updated":"2024-10-18T12:03:17.797178","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/42890aec-3b82-47fa-9745-f726c41cfa8e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/42890aec-3b82-47fa-9745-f726c41cfa8e/pipeline.log\">pipeline</a>"]},{"id":"ff6166b9-4126-47d6-b610-c82dfd2f4571","name":"RHEL9 - 15","status":"complete","outcome":"passed","runTime":1706.593605,"created":"2024-10-18T12:03:26.810014","updated":"2024-10-18T12:03:26.810023","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ff6166b9-4126-47d6-b610-c82dfd2f4571\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ff6166b9-4126-47d6-b610-c82dfd2f4571/pipeline.log\">pipeline</a>"]},{"id":"4f3a2d74-cf23-46c0-bab2-81e4411d353d","name":"RHEL8 - 12","status":"complete","outcome":"passed","runTime":1768.930129,"created":"2024-10-18T12:03:08.144682","updated":"2024-10-18T12:03:08.144689","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4f3a2d74-cf23-46c0-bab2-81e4411d353d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4f3a2d74-cf23-46c0-bab2-81e4411d353d/pipeline.log\">pipeline</a>"]},{"id":"a8ac04d6-c54f-4ee4-9d8a-71ed5857bcc0","name":"RHEL8 - 13","status":"complete","outcome":"passed","runTime":1799.054429,"created":"2024-10-18T12:03:18.476996","updated":"2024-10-18T12:03:18.477002","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a8ac04d6-c54f-4ee4-9d8a-71ed5857bcc0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a8ac04d6-c54f-4ee4-9d8a-71ed5857bcc0/pipeline.log\">pipeline</a>"]},{"id":"ce638a3f-ab09-49c0-a4da-799eb3a42edf","name":"RHEL9 - 16","status":"complete","outcome":"passed","runTime":1177.631946,"created":"2024-10-18T12:13:39.965156","updated":"2024-10-18T12:13:39.965165","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ce638a3f-ab09-49c0-a4da-799eb3a42edf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ce638a3f-ab09-49c0-a4da-799eb3a42edf/pipeline.log\">pipeline</a>"]},{"id":"1d8c29e3-9ef3-4f93-8e8e-b2590954fdbc","name":"RHEL8 - 15","status":"complete","outcome":"passed","runTime":1873.157412,"created":"2024-10-18T12:03:27.262664","updated":"2024-10-18T12:03:27.262670","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d8c29e3-9ef3-4f93-8e8e-b2590954fdbc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d8c29e3-9ef3-4f93-8e8e-b2590954fdbc/pipeline.log\">pipeline</a>"]},{"id":"aacaaec9-5398-48a8-95e4-de0cebe27a20","name":"RHEL8 - 16","runTime":1450.266515,"created":"2024-10-18T12:13:39.078499","updated":"2024-10-18T12:13:39.078507","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/aacaaec9-5398-48a8-95e4-de0cebe27a20\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/aacaaec9-5398-48a8-95e4-de0cebe27a20/pipeline.log\">pipeline</a>"]}]} -->