### PR TITLE
Enable testing postgresql-container on RHEL10 quest.

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "11", "12", "13", "14", "15", "16" ]
-        os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "rhel10", "c9s", "c10s" ]
         test_case: [ "container" ]
 
     if: |

--- a/.github/workflows/openshift-pytests.yml
+++ b/.github/workflows/openshift-pytests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "12", "13", "14", "15", "16" ]
-        os_test: [ "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9", "rhel10"]
         test_case: [ "openshift-pytest" ]
 
     steps:

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "11", "12", "13", "15", "16" ]
-        os_test: [ "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-4" ]
     steps:
       - uses: sclorg/tfaga-wrapper@main


### PR DESCRIPTION
No code is changed. GitHub Action should not be needed to call




<!-- issue-commentator = {"comment-id":"2592008078"} -->













































































<!-- testing-farm = {"lock":"false","comment-id":"2592034221","data":[{"id":"7703e480-88b6-4cca-8c3a-2beca05cc64c","name":"CentOS Stream 10 - 16","status":"complete","outcome":"passed","runTime":554.477031,"created":"2025-01-15T08:56:45.751596","updated":"2025-01-15T08:56:45.751603","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7703e480-88b6-4cca-8c3a-2beca05cc64c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7703e480-88b6-4cca-8c3a-2beca05cc64c/pipeline.log\">pipeline</a>"]},{"id":"4a214704-8111-4841-8456-3fd0289600f9","name":"CentOS Stream 9 - 13","status":"complete","outcome":"passed","runTime":691.6847,"created":"2025-01-15T08:56:05.219653","updated":"2025-01-15T08:56:05.219662","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4a214704-8111-4841-8456-3fd0289600f9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4a214704-8111-4841-8456-3fd0289600f9/pipeline.log\">pipeline</a>"]},{"id":"174121d8-e35e-45b9-83c4-aa039bae6ec0","name":"CentOS Stream 9 - 15","status":"complete","outcome":"passed","runTime":684.698264,"created":"2025-01-15T08:56:35.481984","updated":"2025-01-15T08:56:35.481990","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/174121d8-e35e-45b9-83c4-aa039bae6ec0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/174121d8-e35e-45b9-83c4-aa039bae6ec0/pipeline.log\">pipeline</a>"]},{"id":"88d1b8c4-2f37-4111-8e81-54d8c33d5d61","name":"Fedora - 15","status":"complete","outcome":"passed","runTime":800.550617,"created":"2025-01-15T08:56:45.155795","updated":"2025-01-15T08:56:45.155802","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/88d1b8c4-2f37-4111-8e81-54d8c33d5d61\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/88d1b8c4-2f37-4111-8e81-54d8c33d5d61/pipeline.log\">pipeline</a>"]},{"id":"686cf069-3513-413b-b21e-6ec9b29ced2d","name":"CentOS Stream 9 - 16","status":"complete","outcome":"passed","runTime":731.563756,"created":"2025-01-15T08:59:49.776957","updated":"2025-01-15T08:59:49.776963","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/686cf069-3513-413b-b21e-6ec9b29ced2d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/686cf069-3513-413b-b21e-6ec9b29ced2d/pipeline.log\">pipeline</a>"]},{"id":"9cf09f42-9b3e-45d8-8c2a-a9a1bba1a94f","name":"Fedora - 16","status":"complete","outcome":"passed","runTime":798.66881,"created":"2025-01-15T09:00:10.916847","updated":"2025-01-15T09:00:10.916854","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9cf09f42-9b3e-45d8-8c2a-a9a1bba1a94f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9cf09f42-9b3e-45d8-8c2a-a9a1bba1a94f/pipeline.log\">pipeline</a>"]},{"id":"aca3a719-71f5-4ab8-be28-d9a214fa308a","name":"RHEL9 - 13","status":"complete","outcome":"passed","runTime":1136.398882,"created":"2025-01-15T08:56:12.316047","updated":"2025-01-15T08:56:12.316054","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/aca3a719-71f5-4ab8-be28-d9a214fa308a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/aca3a719-71f5-4ab8-be28-d9a214fa308a/pipeline.log\">pipeline</a>"]},{"id":"fe705693-8e73-4fdd-b0ee-16ab86e11e21","name":"RHEL9 - 15","status":"complete","outcome":"passed","runTime":1030.263298,"created":"2025-01-15T08:59:50.915595","updated":"2025-01-15T08:59:50.915602","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe705693-8e73-4fdd-b0ee-16ab86e11e21\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe705693-8e73-4fdd-b0ee-16ab86e11e21/pipeline.log\">pipeline</a>"]},{"id":"0d87f11a-bc66-4699-8b9f-cbbe12594edc","name":"RHEL9 - 16","status":"complete","outcome":"passed","runTime":985.119222,"created":"2025-01-15T09:01:17.898031","updated":"2025-01-15T09:01:17.898039","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d87f11a-bc66-4699-8b9f-cbbe12594edc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d87f11a-bc66-4699-8b9f-cbbe12594edc/pipeline.log\">pipeline</a>"]},{"id":"c2045164-ab71-48dd-a1cd-6f8e03dcd1de","name":"RHEL8 - 12","status":"complete","outcome":"passed","runTime":1320.151468,"created":"2025-01-15T08:56:01.978031","updated":"2025-01-15T08:56:01.978037","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2045164-ab71-48dd-a1cd-6f8e03dcd1de\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2045164-ab71-48dd-a1cd-6f8e03dcd1de/pipeline.log\">pipeline</a>"]},{"id":"bf392464-ac8f-4923-931c-0eeb29a01550","name":"RHEL8 - 13","status":"complete","outcome":"passed","runTime":1303.2465,"created":"2025-01-15T08:56:11.871383","updated":"2025-01-15T08:56:11.871397","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf392464-ac8f-4923-931c-0eeb29a01550\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf392464-ac8f-4923-931c-0eeb29a01550/pipeline.log\">pipeline</a>"]},{"id":"8c14005e-4d11-483c-9be7-d363a89e057d","name":"RHEL8 - 15","status":"complete","outcome":"passed","runTime":1406.353725,"created":"2025-01-15T08:56:44.070486","updated":"2025-01-15T08:56:44.070499","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c14005e-4d11-483c-9be7-d363a89e057d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c14005e-4d11-483c-9be7-d363a89e057d/pipeline.log\">pipeline</a>"]},{"id":"ea96a5c6-1ebc-4184-bab1-8aca88a9cb96","name":"RHEL8 - 16","runTime":1345.238675,"created":"2025-01-15T09:01:14.353953","updated":"2025-01-15T09:01:14.353962","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ea96a5c6-1ebc-4184-bab1-8aca88a9cb96\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ea96a5c6-1ebc-4184-bab1-8aca88a9cb96/pipeline.log\">pipeline</a>"]}]} -->