### PR TITLE
Building testing postgresql-container on RHEL10

### DIFF
--- a/12/root/usr/share/container-scripts/postgresql/README.md
+++ b/12/root/usr/share/container-scripts/postgresql/README.md
@@ -200,4 +200,4 @@ Subsequently, log output is redirected to the logging collector process and will
 
 ## Additional Resources
 
-The Dockerfile and other sources related to this container image can be found at https://github.com/sclorg/postgresql-container. In this repository, the RHEL8 Dockerfile is named Dockerfile.rhel8, the RHEL9 Dockerfile is named Dockerfile.rhel9, and the Fedora Dockerfile is named Dockerfile.fedora.
+The Dockerfile and other sources related to this container image can be found at https://github.com/sclorg/postgresql-container. In this repository, the RHEL8 Dockerfile is named Dockerfile.rhel8, the RHEL9 Dockerfile is named Dockerfile.rhel9, the RHEL10 Dockerfile is named Dockerfile.rhel10, and the Fedora Dockerfile is named Dockerfile.fedora.

--- a/13/root/usr/share/container-scripts/postgresql/README.md
+++ b/13/root/usr/share/container-scripts/postgresql/README.md
@@ -200,4 +200,4 @@ Subsequently, log output is redirected to the logging collector process and will
 
 ## Additional Resources
 
-The Dockerfile and other sources related to this container image can be found at https://github.com/sclorg/postgresql-container. In this repository, the RHEL8 Dockerfile is named Dockerfile.rhel8, the RHEL9 Dockerfile is named Dockerfile.rhel9, and the Fedora Dockerfile is named Dockerfile.fedora.
+The Dockerfile and other sources related to this container image can be found at https://github.com/sclorg/postgresql-container. In this repository, the RHEL8 Dockerfile is named Dockerfile.rhel8, the RHEL9 Dockerfile is named Dockerfile.rhel9, the RHEL10 Dockerfile is named Dockerfile.rhel10, and the Fedora Dockerfile is named Dockerfile.fedora.

--- a/15/root/usr/share/container-scripts/postgresql/README.md
+++ b/15/root/usr/share/container-scripts/postgresql/README.md
@@ -200,4 +200,4 @@ Subsequently, log output is redirected to the logging collector process and will
 
 ## Additional Resources
 
-The Dockerfile and other sources related to this container image can be found at https://github.com/sclorg/postgresql-container. In this repository, the RHEL8 Dockerfile is named Dockerfile.rhel8, the RHEL9 Dockerfile is named Dockerfile.rhel9, and the Fedora Dockerfile is named Dockerfile.fedora.
+The Dockerfile and other sources related to this container image can be found at https://github.com/sclorg/postgresql-container. In this repository, the RHEL8 Dockerfile is named Dockerfile.rhel8, the RHEL9 Dockerfile is named Dockerfile.rhel9, the RHEL10 Dockerfile is named Dockerfile.rhel10, and the Fedora Dockerfile is named Dockerfile.fedora.

--- a/16/Dockerfile.rhel10
+++ b/16/Dockerfile.rhel10
@@ -1,0 +1,92 @@
+FROM ubi10/s2i-core
+
+# PostgreSQL image for OpenShift.
+# Volumes:
+#  * /var/lib/pgsql/data   - Database cluster for PostgreSQL
+# Environment:
+#  * $POSTGRESQL_USER     - Database user name
+#  * $POSTGRESQL_PASSWORD - User's password
+#  * $POSTGRESQL_DATABASE - Name of the database to create
+#  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
+#                           PostgreSQL administrative account
+
+ENV POSTGRESQL_VERSION=16 \
+    POSTGRESQL_PREV_VERSION=15 \
+    HOME=/var/lib/pgsql \
+    PGUSER=postgres \
+    APP_DATA=/opt/app-root
+
+ENV SUMMARY="PostgreSQL is an advanced Object-Relational database management system" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
+The image contains the client and server programs that you'll need to \
+create, run, maintain and access a PostgreSQL DBMS server."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="PostgreSQL 16" \
+      io.openshift.expose-services="5432:postgresql" \
+      io.openshift.tags="database,postgresql,postgresql16,postgresql-16" \
+      io.openshift.s2i.assemble-user="26" \
+      name="rhel10/postgresql-16" \
+      com.redhat.component="postgresql-16-container" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      usage="podman run -d --name postgresql_database -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -p 5432:5432 rhel10/postgresql-16" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 5432
+
+COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
+
+# This image must forever use UID 26 for postgres user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs glibc-locale-source xz" && \
+    PSQL_PKGS="postgresql16-server postgresql16-contrib" && \
+    INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
+    INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS $PSQL_PKGS  && \
+    rpm -V $INSTALL_PKGS  && \
+    postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" && \
+    yum -y clean all --enablerepo='*' && \
+    localedef -f UTF-8 -i en_US en_US.UTF-8 && \
+    test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
+    mkdir -p /var/lib/pgsql/data && \
+    mkdir -p /run/postgresql && \
+    /usr/libexec/fix-permissions /var/lib/pgsql /run/postgresql
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
+    ENABLED_COLLECTIONS=
+
+COPY root /
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-postgresql $STI_SCRIPTS_PATH/run
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/var/lib/pgsql/data"]
+
+# S2I permission fixes
+# --------------------
+# 1. unless specified otherwise (or - equivalently - we are in OpenShift), s2i
+#    build process would be executed as 'uid=26(postgres) gid=26(postgres)'.
+#    Such process wouldn't be able to execute the default 'assemble' script
+#    correctly (it transitively executes 'fix-permissions' script).  So let's
+#    add the 'postgres' user into 'root' group here
+#
+# 2. we call fix-permissions on $APP_DATA here directly (UID=0 during build
+#    anyways) to assure that s2i process is actually able to _read_ the
+#    user-specified scripting.
+RUN usermod -a -G root postgres && \
+    /usr/libexec/fix-permissions --read-only "$APP_DATA"
+
+USER 26
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-postgresql"]

--- a/16/root/usr/share/container-scripts/postgresql/README.md
+++ b/16/root/usr/share/container-scripts/postgresql/README.md
@@ -200,4 +200,4 @@ Subsequently, log output is redirected to the logging collector process and will
 
 ## Additional Resources
 
-The Dockerfile and other sources related to this container image can be found at https://github.com/sclorg/postgresql-container. In this repository, the RHEL8 Dockerfile is named Dockerfile.rhel8, the RHEL9 Dockerfile is named Dockerfile.rhel9, and the Fedora Dockerfile is named Dockerfile.fedora.
+The Dockerfile and other sources related to this container image can be found at https://github.com/sclorg/postgresql-container. In this repository, the RHEL8 Dockerfile is named Dockerfile.rhel8, the RHEL9 Dockerfile is named Dockerfile.rhel9, the RHEL10 Dockerfile is named Dockerfile.rhel10, and the Fedora Dockerfile is named Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ PostgreSQL versions currently supported are:
 RHEL versions currently supported are:
 - RHEL8
 - RHEL9
+- RHEL10
 
 CentOS versions currently supported are:
 - CentOS Stream 9

--- a/manifest.yml
+++ b/manifest.yml
@@ -30,6 +30,9 @@ DISTGEN_MULTI_RULES:
     dest: Dockerfile.rhel9
 
   - src: src/Dockerfile
+    dest: Dockerfile.rhel10
+
+  - src: src/Dockerfile
     dest: Dockerfile.c9s
 
   - src: src/Dockerfile

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -52,6 +52,16 @@ specs:
            { yum -y module enable postgresql:{{ spec.version }} || :; } && \
        post_install: >-4
            (yum -y reinstall tzdata || yum -y update tzdata ) && \
+    rhel10:
+       distros:
+         - rhel-10-x86_64
+       s2i_base: ubi10/s2i-core
+       org: "rhel10"
+       prod: "rhel10"
+       openshift_tags: "database,postgresql,postgresql{{ spec.short }},postgresql-{{ spec.short }}"
+       redhat_component: "postgresql-{{ spec.short }}-container"
+       img_name: "{{ spec.org }}/postgresql-{{ spec.short }}"
+       pkgs: "postgresql{{ spec.short }}-server postgresql{{ spec.short }}-contrib"
     c9s:
       distros:
         - centos-stream-9-x86_64
@@ -139,3 +149,4 @@ matrix:
         - centos-stream-9-x86_64
         - fedora-40-x86_64
         - centos-stream-10-x86_64
+        - rhel-10-x86_64

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -55,7 +55,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 {% if spec.repo_enable_reason %}
 {{ spec.repo_enable_reason }}
 {% endif %}
-{% if spec.prod == "c10s" %}
+{% if spec.prod == "c10s" or spec.prod == "rhel10" %}
 RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs glibc-locale-source xz" && \
     PSQL_PKGS="{{ spec.pkgs }}" && \
 {% elif spec.prod == "rhel9" and spec.version == "13" %} \
@@ -70,7 +70,7 @@ RUN {{ spec.environment_setup }}
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     {% endif %}
 {% endif %}
-{% if spec.prod == "c10s" %}
+{% if spec.prod == "c10s" or spec.prod == "rhel10" %}
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS $PSQL_PKGS  && \
     rpm -V $INSTALL_PKGS {{ spec.check_pkgs }} && \
 {% else %}

--- a/src/root/usr/share/container-scripts/postgresql/README.md
+++ b/src/root/usr/share/container-scripts/postgresql/README.md
@@ -200,4 +200,4 @@ Subsequently, log output is redirected to the logging collector process and will
 
 ## Additional Resources
 
-The Dockerfile and other sources related to this container image can be found at https://github.com/sclorg/postgresql-container. In this repository, the RHEL8 Dockerfile is named Dockerfile.rhel8, the RHEL9 Dockerfile is named Dockerfile.rhel9, and the Fedora Dockerfile is named Dockerfile.fedora.
+The Dockerfile and other sources related to this container image can be found at https://github.com/sclorg/postgresql-container. In this repository, the RHEL8 Dockerfile is named Dockerfile.rhel8, the RHEL9 Dockerfile is named Dockerfile.rhel9, the RHEL10 Dockerfile is named Dockerfile.rhel10, and the Fedora Dockerfile is named Dockerfile.fedora.


### PR DESCRIPTION
This pull request is separated into two commit.

The first commit adds support for dist-gen source files for RHEL10. In this case PostgreSQL 16.
The second commit adds distgen generated files.

README.md files are also updated.


<!-- issue-commentator = {"comment-id":"2592438403"} -->































































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2592457007","data":[{"id":"9041be5b-68c2-40c1-9d6f-11e4759ebfa0","name":"CentOS Stream 10 - 16","status":"complete","outcome":"passed","runTime":489.0647,"created":"2025-01-30T09:39:25.640707","updated":"2025-01-30T09:39:25.640715","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9041be5b-68c2-40c1-9d6f-11e4759ebfa0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9041be5b-68c2-40c1-9d6f-11e4759ebfa0/pipeline.log\">pipeline</a>"]},{"id":"af9b956a-2110-4bb5-accb-475742ab8e44","name":"CentOS Stream 9 - 15","status":"complete","outcome":"passed","runTime":618.557878,"created":"2025-01-30T09:39:18.456597","updated":"2025-01-30T09:39:18.456610","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/af9b956a-2110-4bb5-accb-475742ab8e44\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/af9b956a-2110-4bb5-accb-475742ab8e44/pipeline.log\">pipeline</a>"]},{"id":"0f8d560e-d773-4b02-9c2f-00b49a88fd13","name":"CentOS Stream 9 - 16","status":"complete","outcome":"passed","runTime":639.422759,"created":"2025-01-30T09:39:22.775905","updated":"2025-01-30T09:39:22.775912","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0f8d560e-d773-4b02-9c2f-00b49a88fd13\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0f8d560e-d773-4b02-9c2f-00b49a88fd13/pipeline.log\">pipeline</a>"]},{"id":"b44b16ea-b14d-4927-b39a-0bf2781106d6","name":"Fedora - 15","status":"complete","outcome":"passed","runTime":696.624272,"created":"2025-01-30T09:39:18.928292","updated":"2025-01-30T09:39:18.928301","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b44b16ea-b14d-4927-b39a-0bf2781106d6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b44b16ea-b14d-4927-b39a-0bf2781106d6/pipeline.log\">pipeline</a>"]},{"id":"9ae47093-d3b7-470a-a05e-603e0f437b9c","name":"Fedora - 16","status":"complete","outcome":"passed","runTime":674.58849,"created":"2025-01-30T09:39:22.849605","updated":"2025-01-30T09:39:22.849614","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9ae47093-d3b7-470a-a05e-603e0f437b9c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9ae47093-d3b7-470a-a05e-603e0f437b9c/pipeline.log\">pipeline</a>"]},{"id":"2d757a17-69ec-461e-8757-be0d591e4634","name":"RHEL9 - 13","status":"complete","outcome":"passed","runTime":922.994538,"created":"2025-01-30T15:58:07.829188","updated":"2025-01-30T15:58:07.829199","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2d757a17-69ec-461e-8757-be0d591e4634\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2d757a17-69ec-461e-8757-be0d591e4634/pipeline.log\">pipeline</a>"]},{"id":"046ca166-5d11-4171-8ef2-773f20cedd7a","name":"RHEL9 - 15","status":"complete","outcome":"passed","runTime":996.161225,"created":"2025-01-30T09:40:12.131196","updated":"2025-01-30T09:40:12.131203","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/046ca166-5d11-4171-8ef2-773f20cedd7a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/046ca166-5d11-4171-8ef2-773f20cedd7a/pipeline.log\">pipeline</a>"]},{"id":"da111282-3869-4dc4-ab83-c34ff5d29c66","name":"RHEL9 - 16","status":"complete","outcome":"passed","runTime":1029.870144,"created":"2025-01-30T09:39:27.436542","updated":"2025-01-30T09:39:27.436550","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/da111282-3869-4dc4-ab83-c34ff5d29c66\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/da111282-3869-4dc4-ab83-c34ff5d29c66/pipeline.log\">pipeline</a>"]},{"id":"bbcc1e1a-5d80-472c-9f28-5b588d6325c0","name":"RHEL8 - 12","status":"complete","outcome":"passed","runTime":1057.087074,"created":"2025-01-30T09:39:08.003723","updated":"2025-01-30T09:39:08.003739","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bbcc1e1a-5d80-472c-9f28-5b588d6325c0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bbcc1e1a-5d80-472c-9f28-5b588d6325c0/pipeline.log\">pipeline</a>"]},{"id":"b82f6e12-6b9f-4c07-bc6d-93dddd88b056","name":"RHEL8 - 13","status":"complete","outcome":"passed","runTime":1183.327831,"created":"2025-01-30T15:58:08.831481","updated":"2025-01-30T15:58:08.831492","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b82f6e12-6b9f-4c07-bc6d-93dddd88b056\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b82f6e12-6b9f-4c07-bc6d-93dddd88b056/pipeline.log\">pipeline</a>"]},{"id":"133447ed-4cdc-4499-b615-8807f181e3be","name":"RHEL8 - 15","status":"complete","outcome":"passed","runTime":1122.236941,"created":"2025-01-30T09:39:22.096962","updated":"2025-01-30T09:39:22.096968","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/133447ed-4cdc-4499-b615-8807f181e3be\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/133447ed-4cdc-4499-b615-8807f181e3be/pipeline.log\">pipeline</a>"]},{"id":"a7eb9b76-848a-4b74-9699-f355ff187747","name":"RHEL8 - 16","runTime":1215.859738,"created":"2025-01-30T15:58:09.267022","updated":"2025-01-30T15:58:09.267040","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7eb9b76-848a-4b74-9699-f355ff187747\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7eb9b76-848a-4b74-9699-f355ff187747/pipeline.log\">pipeline</a>"]},{"id":"b35346a2-902d-4727-a996-3956101e719e","name":"CentOS Stream 9 - 13","status":"complete","outcome":"passed","runTime":572.005277,"created":"2025-01-30T09:39:11.188108","updated":"2025-01-30T09:39:11.188141","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b35346a2-902d-4727-a996-3956101e719e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b35346a2-902d-4727-a996-3956101e719e/pipeline.log\">pipeline</a>"]},{"id":"7d721e49-1137-4f9b-bb9e-4caba8f31006","name":"RHEL10 - 16","status":"complete","outcome":"passed","runTime":879.484176,"created":"2025-01-30T15:58:12.598381","updated":"2025-01-30T15:58:12.598398","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7d721e49-1137-4f9b-bb9e-4caba8f31006\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7d721e49-1137-4f9b-bb9e-4caba8f31006/pipeline.log\">pipeline</a>"]}]} -->