### PR TITLE
Fix postgresql-container test for Helm Charts.

### DIFF
--- a/test/test_shared_helm_postgresql_imagestreams.py
+++ b/test/test_shared_helm_postgresql_imagestreams.py
@@ -20,7 +20,7 @@ class TestHelmRHELPostgresqlImageStreams:
     def setup_method(self):
         package_name = "redhat-postgresql-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_shared_helm_postgresql_imagestreams.py
+++ b/test/test_shared_helm_postgresql_imagestreams.py
@@ -20,7 +20,7 @@ class TestHelmRHELPostgresqlImageStreams:
     def setup_method(self):
         package_name = "redhat-postgresql-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_shared_helm_postgresql_imagestreams.py
+++ b/test/test_shared_helm_postgresql_imagestreams.py
@@ -18,7 +18,7 @@ test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 class TestHelmRHELPostgresqlImageStreams:
 
     def setup_method(self):
-        package_name = "postgresql-imagestreams"
+        package_name = "redhat-postgresql-imagestreams"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
         self.hc_api.clone_helm_chart_repo(

--- a/test/test_shared_helm_postgresql_template.py
+++ b/test/test_shared_helm_postgresql_template.py
@@ -49,8 +49,8 @@ class TestHelmPostgresqlPersistent:
         assert self.hc_api.helm_installation(
             values={
                 ".image.tag": f"{VERSION}{TAG}",
-                ".namespace": self.hc_api.namespace
+                ".namespace": self.hc_api.namespace,
             }
         )
-        assert self.hc_api.is_pod_running(pod_name_prefix="postgresql-persistent")
+        assert self.hc_api.is_pod_running(pod_name_prefix="redhat-postgresql-persistent")
         assert self.hc_api.test_helm_chart(expected_str=["accepting connection"])

--- a/test/test_shared_helm_postgresql_template.py
+++ b/test/test_shared_helm_postgresql_template.py
@@ -29,7 +29,7 @@ TAG = TAGS.get(OS, None)
 class TestHelmPostgresqlPersistent:
 
     def setup_method(self):
-        package_name = "postgresql-persistent"
+        package_name = "redhat-postgresql-persistent"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
         self.hc_api.clone_helm_chart_repo(
@@ -41,10 +41,10 @@ class TestHelmPostgresqlPersistent:
         self.hc_api.delete_project()
 
     def test_package_persistent(self):
-        self.hc_api.package_name = "postgresql-imagestreams"
+        self.hc_api.package_name = "redhat-postgresql-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "postgresql-persistent"
+        self.hc_api.package_name = "redhat-postgresql-persistent"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={

--- a/test/test_shared_helm_postgresql_template.py
+++ b/test/test_shared_helm_postgresql_template.py
@@ -31,7 +31,7 @@ class TestHelmPostgresqlPersistent:
     def setup_method(self):
         package_name = "redhat-postgresql-persistent"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"


### PR DESCRIPTION
The helm charts have been renamed
from `postgresql-*` -> `redhat-postgresql-*`

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- issue-commentator = {"comment-id":"2650102047"} -->



































































































































































































































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2650226173","data":[{"id":"d77e94bb-b45f-434a-8cc2-ea90187c55ac","name":"RHEL10 - PyTest - OpenShift 4 - 16","runTime":2668.660579,"created":"2025-02-14T10:34:57.945321","updated":"2025-02-14T10:34:57.945329","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d77e94bb-b45f-434a-8cc2-ea90187c55ac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d77e94bb-b45f-434a-8cc2-ea90187c55ac/pipeline.log\">pipeline</a>"]},{"id":"9aa59c7a-b31f-4261-a6d0-706f2623f8e9","name":"RHEL9 - PyTest - OpenShift 4 - 15","status":"complete","outcome":"passed","runTime":1016.638489,"created":"2025-02-14T10:34:55.915385","updated":"2025-02-14T10:34:55.915391","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9aa59c7a-b31f-4261-a6d0-706f2623f8e9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9aa59c7a-b31f-4261-a6d0-706f2623f8e9/pipeline.log\">pipeline</a>"]},{"id":"99602921-65ab-4025-b48e-c1cffdee4e34","name":"RHEL9 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":1061.421481,"created":"2025-02-14T10:34:58.863706","updated":"2025-02-14T10:34:58.863713","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/99602921-65ab-4025-b48e-c1cffdee4e34\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/99602921-65ab-4025-b48e-c1cffdee4e34/pipeline.log\">pipeline</a>"]},{"id":"e2efca0e-671a-48d7-ae86-90bdcc5dbf15","name":"RHEL8 - PyTest - OpenShift 4 - 13","status":"complete","outcome":"passed","runTime":1436.885317,"created":"2025-02-14T10:34:57.441955","updated":"2025-02-14T10:34:57.441962","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e2efca0e-671a-48d7-ae86-90bdcc5dbf15\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e2efca0e-671a-48d7-ae86-90bdcc5dbf15/pipeline.log\">pipeline</a>"]},{"id":"015a1d4b-447d-4efd-98fa-4f5fb170b9c9","name":"RHEL8 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":1422.503006,"created":"2025-02-14T10:34:58.188699","updated":"2025-02-14T10:34:58.188707","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/015a1d4b-447d-4efd-98fa-4f5fb170b9c9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/015a1d4b-447d-4efd-98fa-4f5fb170b9c9/pipeline.log\">pipeline</a>"]},{"id":"485a4a10-e7f4-4c02-8c3d-f152cd427ea3","name":"RHEL9 - PyTest - OpenShift 4 - 13","status":"complete","outcome":"passed","runTime":1031.002543,"created":"2025-02-14T10:34:56.650646","updated":"2025-02-14T10:34:56.650656","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/485a4a10-e7f4-4c02-8c3d-f152cd427ea3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/485a4a10-e7f4-4c02-8c3d-f152cd427ea3/pipeline.log\">pipeline</a>"]},{"id":"b5542b0d-29e0-407a-aec2-b44a42bcd3af","name":"RHEL8 - PyTest - OpenShift 4 - 12","status":"complete","outcome":"passed","runTime":1328.517217,"created":"2025-02-14T10:34:54.749825","updated":"2025-02-14T10:34:54.749834","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b5542b0d-29e0-407a-aec2-b44a42bcd3af\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b5542b0d-29e0-407a-aec2-b44a42bcd3af/pipeline.log\">pipeline</a>"]},{"id":"93b0fba9-e3ab-4b5f-b49f-2b681cf15d54","name":"RHEL8 - PyTest - OpenShift 4 - 15","status":"complete","outcome":"passed","runTime":1315.227523,"created":"2025-02-14T10:34:56.619212","updated":"2025-02-14T10:34:56.619220","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/93b0fba9-e3ab-4b5f-b49f-2b681cf15d54\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/93b0fba9-e3ab-4b5f-b49f-2b681cf15d54/pipeline.log\">pipeline</a>"]},{"id":"28cfc4ac-6c82-4f63-8308-05604f04077f","name":"RHEL9 - OpenShift 4 - 13","status":"complete","outcome":"passed","runTime":901.341498,"created":"2025-02-14T10:48:50.532901","updated":"2025-02-14T10:48:50.532908","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/28cfc4ac-6c82-4f63-8308-05604f04077f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/28cfc4ac-6c82-4f63-8308-05604f04077f/pipeline.log\">pipeline</a>"]},{"id":"cbc88b3b-e44f-4c20-a296-db7ed9c7ef93","name":"RHEL8 - OpenShift 4 - 13","status":"complete","outcome":"passed","runTime":1278.246306,"created":"2025-02-14T10:47:24.151455","updated":"2025-02-14T10:47:24.151464","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cbc88b3b-e44f-4c20-a296-db7ed9c7ef93\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cbc88b3b-e44f-4c20-a296-db7ed9c7ef93/pipeline.log\">pipeline</a>"]},{"id":"3adc0fde-3d32-4a68-8b2c-b80e0def15df","name":"RHEL8 - OpenShift 4 - 12","status":"complete","outcome":"passed","runTime":1127.879126,"created":"2025-02-14T10:46:52.203872","updated":"2025-02-14T10:46:52.203879","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3adc0fde-3d32-4a68-8b2c-b80e0def15df\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3adc0fde-3d32-4a68-8b2c-b80e0def15df/pipeline.log\">pipeline</a>"]},{"id":"60b0edfd-e864-4b3b-ad81-b9ba3f036f5d","name":"RHEL8 - OpenShift 4 - 15","status":"complete","outcome":"passed","runTime":1149.12918,"created":"2025-02-14T10:51:44.877105","updated":"2025-02-14T10:51:44.877142","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/60b0edfd-e864-4b3b-ad81-b9ba3f036f5d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/60b0edfd-e864-4b3b-ad81-b9ba3f036f5d/pipeline.log\">pipeline</a>"]},{"id":"55db5b1c-0c4e-481e-95cb-3c23eb78d773","name":"RHEL9 - OpenShift 4 - 15","status":"complete","outcome":"passed","runTime":894.150065,"created":"2025-02-14T10:48:53.696897","updated":"2025-02-14T10:48:53.696903","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/55db5b1c-0c4e-481e-95cb-3c23eb78d773\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/55db5b1c-0c4e-481e-95cb-3c23eb78d773/pipeline.log\">pipeline</a>"]},{"id":"99e2435b-7c03-4ea0-be5f-995b0fb56175","name":"RHEL10 - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":759.81277,"created":"2025-02-14T10:52:49.149488","updated":"2025-02-14T10:52:49.149494","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/99e2435b-7c03-4ea0-be5f-995b0fb56175\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/99e2435b-7c03-4ea0-be5f-995b0fb56175/pipeline.log\">pipeline</a>"]},{"id":"22b16c20-a07e-47c8-b1a1-48a8ec56b97f","name":"RHEL9 - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":900.980542,"created":"2025-02-14T10:52:50.612926","updated":"2025-02-14T10:52:50.612933","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/22b16c20-a07e-47c8-b1a1-48a8ec56b97f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/22b16c20-a07e-47c8-b1a1-48a8ec56b97f/pipeline.log\">pipeline</a>"]},{"id":"4a46538c-fbd7-49b7-bb04-f44ef4bd2b1f","name":"RHEL8 - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":1112.083003,"created":"2025-02-14T10:51:57.858394","updated":"2025-02-14T10:51:57.858403","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4a46538c-fbd7-49b7-bb04-f44ef4bd2b1f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4a46538c-fbd7-49b7-bb04-f44ef4bd2b1f/pipeline.log\">pipeline</a>"]},{"id":"f6f8c683-6596-4057-8738-77163af81f37","name":"CentOS Stream 10 - 16","status":"complete","outcome":"passed","runTime":508.959094,"created":"2025-02-14T10:35:45.872539","updated":"2025-02-14T10:35:45.872548","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f6f8c683-6596-4057-8738-77163af81f37\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f6f8c683-6596-4057-8738-77163af81f37/pipeline.log\">pipeline</a>"]},{"id":"f27e4ed1-dc0c-4b43-8bc7-a5b1156e1cae","name":"Fedora - 15","status":"complete","outcome":"passed","runTime":539.720748,"created":"2025-02-14T10:35:30.211600","updated":"2025-02-14T10:35:30.211608","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f27e4ed1-dc0c-4b43-8bc7-a5b1156e1cae\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f27e4ed1-dc0c-4b43-8bc7-a5b1156e1cae/pipeline.log\">pipeline</a>"]},{"id":"a46ffb46-3cb0-440b-a279-0ba42683e93f","name":"Fedora - 16","status":"complete","outcome":"passed","runTime":551.998577,"created":"2025-02-14T10:35:50.174372","updated":"2025-02-14T10:35:50.174380","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a46ffb46-3cb0-440b-a279-0ba42683e93f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a46ffb46-3cb0-440b-a279-0ba42683e93f/pipeline.log\">pipeline</a>"]},{"id":"d7070229-fe57-4cc4-926b-27c637911cd2","name":"CentOS Stream 9 - 13","status":"complete","outcome":"passed","runTime":649.811883,"created":"2025-02-14T10:35:16.471016","updated":"2025-02-14T10:35:16.471023","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d7070229-fe57-4cc4-926b-27c637911cd2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d7070229-fe57-4cc4-926b-27c637911cd2/pipeline.log\">pipeline</a>"]},{"id":"8d90e4c4-e103-4b3f-bcfb-44d5682fa389","name":"CentOS Stream 9 - 15","status":"complete","outcome":"passed","runTime":683.502629,"created":"2025-02-14T10:35:30.688941","updated":"2025-02-14T10:35:30.688947","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8d90e4c4-e103-4b3f-bcfb-44d5682fa389\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8d90e4c4-e103-4b3f-bcfb-44d5682fa389/pipeline.log\">pipeline</a>"]},{"id":"eaeca372-459b-49f2-b3e8-3dade9d2aafc","name":"CentOS Stream 9 - 16","status":"complete","outcome":"passed","runTime":729.727502,"created":"2025-02-14T10:35:49.765279","updated":"2025-02-14T10:35:49.765288","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/eaeca372-459b-49f2-b3e8-3dade9d2aafc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/eaeca372-459b-49f2-b3e8-3dade9d2aafc/pipeline.log\">pipeline</a>"]},{"id":"f80adbd3-088f-45db-abf7-b5f80cf35ed7","name":"RHEL9 - 13","status":"complete","outcome":"passed","runTime":838.692579,"created":"2025-02-14T10:35:18.272902","updated":"2025-02-14T10:35:18.272910","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f80adbd3-088f-45db-abf7-b5f80cf35ed7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f80adbd3-088f-45db-abf7-b5f80cf35ed7/pipeline.log\">pipeline</a>"]},{"id":"fe1233a4-c985-4514-ab25-020dd3091973","name":"RHEL10 - 16","status":"complete","outcome":"passed","runTime":839.714469,"created":"2025-02-14T10:36:51.583056","updated":"2025-02-14T10:36:51.583065","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe1233a4-c985-4514-ab25-020dd3091973\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe1233a4-c985-4514-ab25-020dd3091973/pipeline.log\">pipeline</a>"]},{"id":"11c4d7b1-dc6f-4d1a-b1a2-2b8bd64a6f42","name":"RHEL9 - 15","status":"complete","outcome":"passed","runTime":1021.333785,"created":"2025-02-14T10:35:36.988469","updated":"2025-02-14T10:35:36.988476","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/11c4d7b1-dc6f-4d1a-b1a2-2b8bd64a6f42\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/11c4d7b1-dc6f-4d1a-b1a2-2b8bd64a6f42/pipeline.log\">pipeline</a>"]},{"id":"9e1bc431-facc-4f33-8215-e5fc1a18b62f","name":"RHEL8 - 12","status":"complete","outcome":"passed","runTime":1174.675338,"created":"2025-02-14T10:35:15.614160","updated":"2025-02-14T10:35:15.614168","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9e1bc431-facc-4f33-8215-e5fc1a18b62f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9e1bc431-facc-4f33-8215-e5fc1a18b62f/pipeline.log\">pipeline</a>"]},{"id":"9f17b8ef-a17a-475d-8950-4fb51ba2f69d","name":"RHEL8 - 15","status":"complete","outcome":"passed","runTime":1237.939679,"created":"2025-02-14T10:35:37.572219","updated":"2025-02-14T10:35:37.572229","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9f17b8ef-a17a-475d-8950-4fb51ba2f69d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9f17b8ef-a17a-475d-8950-4fb51ba2f69d/pipeline.log\">pipeline</a>"]},{"id":"8d59a3ac-7a99-4451-9cc1-18551d7e003c","name":"RHEL8 - 13","status":"complete","outcome":"passed","runTime":1278.041245,"created":"2025-02-14T10:35:22.443711","updated":"2025-02-14T10:35:22.443717","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d59a3ac-7a99-4451-9cc1-18551d7e003c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d59a3ac-7a99-4451-9cc1-18551d7e003c/pipeline.log\">pipeline</a>"]},{"id":"cd7ce209-5156-4401-a093-78815b7c13da","name":"RHEL9 - 16","status":"complete","outcome":"passed","runTime":1016.821108,"created":"2025-02-14T10:45:39.500736","updated":"2025-02-14T10:45:39.500744","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd7ce209-5156-4401-a093-78815b7c13da\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd7ce209-5156-4401-a093-78815b7c13da/pipeline.log\">pipeline</a>"]},{"id":"b6e60ac8-ed70-493e-8f6b-66e2b92a8590","name":"RHEL8 - 16","status":"complete","outcome":"passed","runTime":1301.810745,"created":"2025-02-14T10:44:48.605790","updated":"2025-02-14T10:44:48.605799","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6e60ac8-ed70-493e-8f6b-66e2b92a8590\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6e60ac8-ed70-493e-8f6b-66e2b92a8590/pipeline.log\">pipeline</a>"]}]} -->