### PR TITLE
Rename package bind-utils to bind9.18-utils

### DIFF
--- a/13/Dockerfile.rhel9
+++ b/13/Dockerfile.rhel9
@@ -43,7 +43,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
  \
-RUN INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
+RUN INSTALL_PKGS="rsync tar gettext bind9.18-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/15/Dockerfile.rhel9
+++ b/15/Dockerfile.rhel9
@@ -43,7 +43,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN { yum -y module enable postgresql:15 || :; } && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind9.18-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/16/Dockerfile.rhel9
+++ b/16/Dockerfile.rhel9
@@ -43,7 +43,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN { yum -y module enable postgresql:16 || :; } && \
-    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
+    INSTALL_PKGS="rsync tar gettext bind9.18-utils nss_wrapper-libs postgresql-server postgresql-contrib" && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     INSTALL_PKGS="$INSTALL_PKGS procps-ng util-linux postgresql-upgrade" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -59,7 +59,10 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 RUN INSTALL_PKGS="rsync tar gettext-envsubst bind-utils nss_wrapper-libs glibc-locale-source xz" && \
     PSQL_PKGS="{{ spec.pkgs }}" && \
 {% elif spec.prod == "rhel9" and spec.version == "13" %} \
-RUN INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs {{ spec.pkgs }}" && \
+RUN INSTALL_PKGS="rsync tar gettext bind9.18-utils nss_wrapper-libs {{ spec.pkgs }}" && \
+{% elif spec.prod == "rhel9" and spec.version in ["15", "16"] %}
+RUN {{ spec.environment_setup }}
+    INSTALL_PKGS="rsync tar gettext bind9.18-utils nss_wrapper-libs {{ spec.pkgs }}" && \
 {% else %}
 RUN {{ spec.environment_setup }}
     INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper-libs {{ spec.pkgs }}" && \


### PR DESCRIPTION
Replace 'bind-utils' with 'bind9.18-utils'

See Jira issue https://issues.redhat.com/browse/RHEL-80345

It is valid only for RHEL9

<!-- issue-commentator = {"comment-id":"2747284809"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2747302731","data":[{"id":"e00fc3db-f884-4619-a4f2-bf220ab152e9","name":"CentOS Stream 10 - 16","status":"complete","outcome":"passed","runTime":389.036883,"created":"2025-03-24T08:29:46.620833","updated":"2025-03-24T08:29:46.620841","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e00fc3db-f884-4619-a4f2-bf220ab152e9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e00fc3db-f884-4619-a4f2-bf220ab152e9/pipeline.log\">pipeline</a>"]},{"id":"e3b16ed6-200a-4c46-ac7b-c6310d1eea64","name":"CentOS Stream 9 - 13","status":"complete","outcome":"passed","runTime":428.879726,"created":"2025-03-24T08:29:40.239228","updated":"2025-03-24T08:29:40.239235","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e3b16ed6-200a-4c46-ac7b-c6310d1eea64\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e3b16ed6-200a-4c46-ac7b-c6310d1eea64/pipeline.log\">pipeline</a>"]},{"id":"088c5ad4-6db7-4274-844c-87b56a637392","name":"CentOS Stream 9 - 15","status":"complete","outcome":"passed","runTime":484.78056,"created":"2025-03-24T08:29:40.469887","updated":"2025-03-24T08:29:40.469893","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/088c5ad4-6db7-4274-844c-87b56a637392\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/088c5ad4-6db7-4274-844c-87b56a637392/pipeline.log\">pipeline</a>"]},{"id":"9b03d04d-8e10-4147-bb10-04722fe9aefb","name":"CentOS Stream 9 - 16","status":"complete","outcome":"passed","runTime":495.091431,"created":"2025-03-24T08:29:50.680042","updated":"2025-03-24T08:29:50.680048","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9b03d04d-8e10-4147-bb10-04722fe9aefb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9b03d04d-8e10-4147-bb10-04722fe9aefb/pipeline.log\">pipeline</a>"]},{"id":"44b90959-7d31-4739-8afe-eaa72a1eff0d","name":"RHEL9 - OpenShift 4 - 13","status":"complete","outcome":"passed","runTime":978.946914,"created":"2025-03-24T10:04:56.381523","updated":"2025-03-24T10:04:56.381529","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/44b90959-7d31-4739-8afe-eaa72a1eff0d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/44b90959-7d31-4739-8afe-eaa72a1eff0d/pipeline.log\">pipeline</a>"]},{"id":"271a17f8-8152-4fa5-9e7b-9d6053bad84e","name":"RHEL8 - 15","status":"complete","outcome":"passed","runTime":1263.936214,"created":"2025-03-24T09:43:48.693460","updated":"2025-03-24T09:43:48.693468","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/271a17f8-8152-4fa5-9e7b-9d6053bad84e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/271a17f8-8152-4fa5-9e7b-9d6053bad84e/pipeline.log\">pipeline</a>"]},{"id":"127215b9-7d7b-4f3a-9f67-3c178b09574c","name":"RHEL9 - 16","status":"complete","outcome":"passed","runTime":1025.534927,"created":"2025-03-24T09:43:49.330677","updated":"2025-03-24T09:43:49.330685","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/127215b9-7d7b-4f3a-9f67-3c178b09574c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/127215b9-7d7b-4f3a-9f67-3c178b09574c/pipeline.log\">pipeline</a>"]},{"id":"84a2fb59-b4dd-48be-83ce-5c2063571a12","name":"RHEL8 - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":1116.309583,"created":"2025-03-24T10:04:58.538421","updated":"2025-03-24T10:04:58.538427","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/84a2fb59-b4dd-48be-83ce-5c2063571a12\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/84a2fb59-b4dd-48be-83ce-5c2063571a12/pipeline.log\">pipeline</a>"]},{"id":"e0de4361-c8d1-40f5-beee-9bf37011b4a6","name":"RHEL8 - OpenShift 4 - 12","status":"complete","outcome":"passed","runTime":1106.717603,"created":"2025-03-24T10:04:55.366730","updated":"2025-03-24T10:04:55.366738","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e0de4361-c8d1-40f5-beee-9bf37011b4a6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e0de4361-c8d1-40f5-beee-9bf37011b4a6/pipeline.log\">pipeline</a>"]},{"id":"f113558a-eda2-4d69-ad4f-1993e775f53e","name":"RHEL8 - 16","status":"complete","outcome":"passed","runTime":1322.970257,"created":"2025-03-24T09:43:51.033433","updated":"2025-03-24T09:43:51.033440","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f113558a-eda2-4d69-ad4f-1993e775f53e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f113558a-eda2-4d69-ad4f-1993e775f53e/pipeline.log\">pipeline</a>"]},{"id":"8e19b6ef-8ae5-40d1-8718-b1c80ce3d1d6","name":"Fedora - 15","status":"complete","outcome":"passed","runTime":566.782628,"created":"2025-03-24T08:29:40.180020","updated":"2025-03-24T08:29:40.180026","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8e19b6ef-8ae5-40d1-8718-b1c80ce3d1d6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8e19b6ef-8ae5-40d1-8718-b1c80ce3d1d6/pipeline.log\">pipeline</a>"]},{"id":"1c275e81-2100-4fb8-b3e2-cde1c0e65156","name":"Fedora - 16","status":"complete","outcome":"passed","runTime":583.699303,"created":"2025-03-24T08:29:34.360925","updated":"2025-03-24T08:29:34.360933","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1c275e81-2100-4fb8-b3e2-cde1c0e65156\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1c275e81-2100-4fb8-b3e2-cde1c0e65156/pipeline.log\">pipeline</a>"]},{"id":"48379745-49a2-4016-a18c-e81bd6ff42f9","name":"RHEL9 - 15","status":"complete","outcome":"passed","runTime":967.776935,"created":"2025-03-24T09:43:49.906385","updated":"2025-03-24T09:43:49.906392","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/48379745-49a2-4016-a18c-e81bd6ff42f9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/48379745-49a2-4016-a18c-e81bd6ff42f9/pipeline.log\">pipeline</a>"]},{"id":"902f133c-0075-4ea6-9a44-8cc691b76326","name":"RHEL9 - OpenShift 4 - 15","status":"complete","outcome":"passed","runTime":906.520549,"created":"2025-03-24T10:04:56.903710","updated":"2025-03-24T10:04:56.903717","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/902f133c-0075-4ea6-9a44-8cc691b76326\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/902f133c-0075-4ea6-9a44-8cc691b76326/pipeline.log\">pipeline</a>"]},{"id":"6662607c-d8c7-4d75-a27c-1afa70172ca7","name":"RHEL8 - 12","status":"complete","outcome":"passed","runTime":1166.246998,"created":"2025-03-24T09:43:49.720327","updated":"2025-03-24T09:43:49.720334","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6662607c-d8c7-4d75-a27c-1afa70172ca7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6662607c-d8c7-4d75-a27c-1afa70172ca7/pipeline.log\">pipeline</a>"]},{"id":"8ad06ddd-a6c7-4109-a279-97a8e91b3e52","name":"RHEL9 - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":939.161807,"created":"2025-03-24T10:04:55.916265","updated":"2025-03-24T10:04:55.916271","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ad06ddd-a6c7-4109-a279-97a8e91b3e52\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ad06ddd-a6c7-4109-a279-97a8e91b3e52/pipeline.log\">pipeline</a>"]},{"id":"b195bdff-a6ce-4781-b613-18b9d63eb670","name":"RHEL8 - OpenShift 4 - 13","runTime":1214.190233,"created":"2025-03-24T10:04:55.672339","updated":"2025-03-24T10:04:55.672345","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b195bdff-a6ce-4781-b613-18b9d63eb670\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b195bdff-a6ce-4781-b613-18b9d63eb670/pipeline.log\">pipeline</a>"]},{"id":"56a09884-4b06-4ede-8c6d-9c3efc3f6f39","name":"RHEL8 - 13","status":"complete","outcome":"passed","runTime":1214.962939,"created":"2025-03-24T09:43:49.508432","updated":"2025-03-24T09:43:49.508441","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/56a09884-4b06-4ede-8c6d-9c3efc3f6f39\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/56a09884-4b06-4ede-8c6d-9c3efc3f6f39/pipeline.log\">pipeline</a>"]},{"id":"3ca1b844-c9c4-4dc6-9915-d505ab5270de","name":"RHEL8 - OpenShift 4 - 15","status":"complete","outcome":"passed","runTime":1173.183193,"created":"2025-03-24T10:04:55.619505","updated":"2025-03-24T10:04:55.619511","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3ca1b844-c9c4-4dc6-9915-d505ab5270de\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3ca1b844-c9c4-4dc6-9915-d505ab5270de/pipeline.log\">pipeline</a>"]},{"id":"9e091e4e-e0c3-43eb-96f2-08de3f2740f6","name":"RHEL10 - 16","status":"complete","outcome":"passed","runTime":990.318264,"created":"2025-03-24T09:43:50.299279","updated":"2025-03-24T09:43:50.299287","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9e091e4e-e0c3-43eb-96f2-08de3f2740f6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9e091e4e-e0c3-43eb-96f2-08de3f2740f6/pipeline.log\">pipeline</a>"]},{"id":"e11d1761-21e1-47d4-80b9-873c97c3e38f","name":"RHEL10 - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":720.432375,"created":"2025-03-24T10:04:55.601159","updated":"2025-03-24T10:04:55.601167","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e11d1761-21e1-47d4-80b9-873c97c3e38f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e11d1761-21e1-47d4-80b9-873c97c3e38f/pipeline.log\">pipeline</a>"]},{"id":"7e031bb5-e7bd-4e17-a156-9059bde106b6","name":"RHEL9 - 13","status":"complete","outcome":"passed","runTime":1002.629365,"created":"2025-03-24T09:43:50.064563","updated":"2025-03-24T09:43:50.064571","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7e031bb5-e7bd-4e17-a156-9059bde106b6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7e031bb5-e7bd-4e17-a156-9059bde106b6/pipeline.log\">pipeline</a>"]}]} -->