### PR TITLE
Add missing brackets in action

### DIFF
--- a/.github/workflows/auto-merge-on-demand.yml
+++ b/.github/workflows/auto-merge-on-demand.yml
@@ -19,7 +19,7 @@ jobs:
     if: |
       github.repository_owner == 'sclorg'
       || (contains(github.event.comment.body, '/auto-merge')
-      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
 
     outputs:


### PR DESCRIPTION
The bracket is missing in GitHub Action.

<!-- issue-commentator = {"comment-id":"2943643933"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2943668469","data":[{"id":"717386de-aa44-4fe9-ab1c-5cbdb2b374e7","name":"CentOS Stream 9 - 13","status":"complete","outcome":"passed","runTime":471.535386,"created":"2025-06-05T10:30:11.375492","updated":"2025-06-05T10:30:11.375498","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/717386de-aa44-4fe9-ab1c-5cbdb2b374e7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/717386de-aa44-4fe9-ab1c-5cbdb2b374e7/pipeline.log\">pipeline</a>"]},{"id":"b01e30ac-7519-45d7-9c56-973bb47f4cf8","name":"CentOS Stream 10 - 16","status":"complete","outcome":"passed","runTime":378.251654,"created":"2025-06-05T10:30:22.681726","updated":"2025-06-05T10:30:22.681732","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b01e30ac-7519-45d7-9c56-973bb47f4cf8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b01e30ac-7519-45d7-9c56-973bb47f4cf8/pipeline.log\">pipeline</a>"]},{"id":"39e8bd46-0e84-4e31-a137-a4a8cf4589fc","name":"CentOS Stream 9 - 16","status":"complete","outcome":"passed","runTime":545.347154,"created":"2025-06-05T10:30:09.595131","updated":"2025-06-05T10:30:09.595140","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/39e8bd46-0e84-4e31-a137-a4a8cf4589fc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/39e8bd46-0e84-4e31-a137-a4a8cf4589fc/pipeline.log\">pipeline</a>"]},{"id":"62d677c0-6e0a-4a6b-a98b-7a6ae2df39a9","name":"CentOS Stream 9 - 15","status":"complete","outcome":"passed","runTime":547.49827,"created":"2025-06-05T10:30:16.717012","updated":"2025-06-05T10:30:16.717020","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/62d677c0-6e0a-4a6b-a98b-7a6ae2df39a9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/62d677c0-6e0a-4a6b-a98b-7a6ae2df39a9/pipeline.log\">pipeline</a>"]},{"id":"eafd1129-6a50-4511-b9b8-66d7aa91f565","name":"Fedora - 16","status":"complete","outcome":"passed","runTime":523.152488,"created":"2025-06-05T10:30:23.429491","updated":"2025-06-05T10:30:23.429499","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/eafd1129-6a50-4511-b9b8-66d7aa91f565\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/eafd1129-6a50-4511-b9b8-66d7aa91f565/pipeline.log\">pipeline</a>"]},{"id":"17ad6080-acc8-4ebd-a189-23f7e0ddcc30","name":"Fedora - 15","status":"complete","outcome":"passed","runTime":650.322446,"created":"2025-06-05T10:30:09.576909","updated":"2025-06-05T10:30:09.576916","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/17ad6080-acc8-4ebd-a189-23f7e0ddcc30\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/17ad6080-acc8-4ebd-a189-23f7e0ddcc30/pipeline.log\">pipeline</a>"]},{"id":"8032eb1a-aefe-44bd-9d57-eca74bd5e74f","name":"RHEL10 - 16","status":"complete","outcome":"passed","runTime":908.671867,"created":"2025-06-05T10:30:27.991643","updated":"2025-06-05T10:30:27.991649","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8032eb1a-aefe-44bd-9d57-eca74bd5e74f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8032eb1a-aefe-44bd-9d57-eca74bd5e74f/pipeline.log\">pipeline</a>"]},{"id":"0c588586-3c6c-401d-935d-ead71954a138","name":"RHEL9 - 13","status":"complete","outcome":"passed","runTime":1023.551638,"created":"2025-06-05T10:30:21.290828","updated":"2025-06-05T10:30:21.290837","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c588586-3c6c-401d-935d-ead71954a138\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c588586-3c6c-401d-935d-ead71954a138/pipeline.log\">pipeline</a>"]},{"id":"9b4c68f3-ad36-49d3-a0e0-5d875e090546","name":"RHEL8 - 12","status":"complete","outcome":"passed","runTime":1091.489398,"created":"2025-06-05T10:30:11.783393","updated":"2025-06-05T10:30:11.783400","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9b4c68f3-ad36-49d3-a0e0-5d875e090546\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9b4c68f3-ad36-49d3-a0e0-5d875e090546/pipeline.log\">pipeline</a>"]},{"id":"ffb476b7-202c-46b6-ba4d-97bb082b5037","name":"RHEL9 - 16","status":"complete","outcome":"passed","runTime":1182.952829,"created":"2025-06-05T10:30:28.015805","updated":"2025-06-05T10:30:28.015813","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ffb476b7-202c-46b6-ba4d-97bb082b5037\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ffb476b7-202c-46b6-ba4d-97bb082b5037/pipeline.log\">pipeline</a>"]},{"id":"3a3d97a2-6e4b-4d07-85eb-c04cc8e23d96","name":"RHEL9 - 15","status":"complete","outcome":"passed","runTime":1085.2734,"created":"2025-06-05T10:30:28.162731","updated":"2025-06-05T10:30:28.162740","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a3d97a2-6e4b-4d07-85eb-c04cc8e23d96\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a3d97a2-6e4b-4d07-85eb-c04cc8e23d96/pipeline.log\">pipeline</a>"]},{"id":"e446f748-c2b5-43c4-b8ea-af178fd23eb7","name":"RHEL8 - 15","status":"complete","outcome":"passed","runTime":1222.033031,"created":"2025-06-05T10:30:22.477558","updated":"2025-06-05T10:30:22.477564","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e446f748-c2b5-43c4-b8ea-af178fd23eb7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e446f748-c2b5-43c4-b8ea-af178fd23eb7/pipeline.log\">pipeline</a>"]},{"id":"3c2c92ae-ac82-4b3b-835d-1df775029009","name":"RHEL8 - 13","runTime":1260.745213,"created":"2025-06-05T10:30:29.364612","updated":"2025-06-05T10:30:29.364618","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c2c92ae-ac82-4b3b-835d-1df775029009\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c2c92ae-ac82-4b3b-835d-1df775029009/pipeline.log\">pipeline</a>"]}]} -->