### PR TITLE
Rename constanst.py to conftest.py

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,73 @@
+import os
+import sys
+
+from pathlib import Path
+from collections import namedtuple
+
+from container_ci_suite.utils import check_variables
+
+if not check_variables():
+    sys.exit(1)
+
+TEST_DIR = Path(__file__).parent.absolute()
+Vars = namedtuple(
+    "Vars",
+    [
+        "OS",
+        "VERSION",
+        "IMAGE_NAME",
+        "TEST_DIR",
+        "TAG",
+        "TEST_APP",
+        "VERY_LONG_IDENTIFIER",
+    ],
+)
+VERSION = os.getenv("VERSION")
+OS = os.getenv("TARGET").lower()
+TEST_APP = TEST_DIR / "test-app"
+VERY_LONG_IDENTIFIER = "very_long_identifier_" + "x" * 40
+VARS = Vars(
+    OS=OS,
+    VERSION=VERSION,
+    IMAGE_NAME=os.getenv("IMAGE_NAME"),
+    TEST_DIR=TEST_DIR,
+    TAG=OS.replace("rh", "-", 1),
+    TEST_APP=TEST_APP,
+    VERY_LONG_IDENTIFIER=VERY_LONG_IDENTIFIER,
+)
+
+
+def get_previous_major_version():
+    version_dict = {
+        "13": "12",
+        "15": "13",
+        "16": "15",
+    }
+    return version_dict.get(VARS.VERSION)
+
+
+def get_upgrade_path():
+    upgrade_path = {
+        "rhel8": "none 12 13 15 16 none",
+        "rhel9": "none 13 15 16 none",
+        "rhel10": "none 13 15 16 none",
+        "fedora": "none 12 13 14 15 16 none",
+    }
+    for version in upgrade_path.keys():
+        if version == VARS.VERSION:
+            break
+        prev = version
+    if prev == "none":
+        return None
+    return prev
+
+
+def get_image_id(version):
+    ns = {
+        "rhel8": f"registry.redhat.io/rhel8/postgresql-{version}",
+        "rhel9": f"registry.redhat.io/rhel9/postgresql-{version}",
+        "rhel10": f"registry.redhat.io/rhel10/postgresql-{version}",
+        "c9s": f"quay.io/sclorg/postgresql-{version}-c9s",
+        "c10s": f"quay.io/sclorg/postgresql-{version}-c10s",
+    }
+    return ns[VARS.OS]

--- a/test/constants.py
+++ b/test/constants.py
@@ -1,5 +1,0 @@
-TAGS = {
-    "rhel8": "-el8",
-    "rhel9": "-el9",
-    "rhel10": "-el10",
-}

--- a/test/test_ocp_psql_imagestream.py
+++ b/test/test_ocp_psql_imagestream.py
@@ -1,49 +1,29 @@
-import os
-import sys
-
 import pytest
 
 from container_ci_suite.openshift import OpenShiftAPI
-from container_ci_suite.utils import check_variables
 
-from constants import TAGS
-
-if not check_variables():
-    print("At least one variable from IMAGE_NAME, OS, VERSION is missing.")
-    sys.exit(1)
-
-
-VERSION = os.getenv("VERSION")
-IMAGE_NAME = os.getenv("IMAGE_NAME")
-OS = os.getenv("TARGET")
-
-TAG = TAGS.get(OS)
+from conftest import VARS
 
 
 class TestPostgreSQLImagestreamTemplate:
-
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="postgresql", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(
+            pod_name_prefix="postgresql", version=VARS.VERSION, shared_cluster=True
+        )
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     @pytest.mark.parametrize(
         "template",
-        [
-            "postgresql-ephemeral-template.json",
-            "postgresql-persistent-template.json"
-        ]
+        ["postgresql-ephemeral-template.json", "postgresql-persistent-template.json"],
     )
     def test_psql_imagestream_template(self, template):
-        os_name = ''.join(i for i in OS if not i.isdigit())
-        print(os.getcwd())
+        os_name = "".join(i for i in VARS.OS if not i.isdigit())
         assert self.oc_api.deploy_image_stream_template(
             imagestream_file=f"imagestreams/postgresql-{os_name}.json",
             template_file=f"examples/{template}",
             app_name=self.oc_api.pod_name_prefix,
-            openshift_args=[
-                f"POSTGRESQL_VERSION={VERSION}{TAG}"
-            ]
+            openshift_args=[f"POSTGRESQL_VERSION={VARS.VERSION}{VARS.TAG}"],
         )
         assert self.oc_api.is_pod_running(pod_name_prefix=self.oc_api.pod_name_prefix)

--- a/test/test_ocp_psql_imagestream_template.py
+++ b/test/test_ocp_psql_imagestream_template.py
@@ -1,45 +1,28 @@
-import os
-import sys
-
 import pytest
 
 from container_ci_suite.openshift import OpenShiftAPI
-from container_ci_suite.utils import check_variables
 
-from constants import TAGS
-
-if not check_variables():
-    print("At least one variable from IMAGE_NAME, OS, VERSION is missing.")
-    sys.exit(1)
-
-
-VERSION = os.getenv("VERSION")
-IMAGE_NAME = os.getenv("IMAGE_NAME")
-OS = os.getenv("TARGET")
-
-TAG = TAGS.get(OS)
+from conftest import VARS
 
 
 class TestPostgreSQLImagestreamTemplate:
-
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="postgresql", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(
+            pod_name_prefix="postgresql", version=VARS.VERSION, shared_cluster=True
+        )
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     @pytest.mark.parametrize(
         "template",
-        [
-            "postgresql-ephemeral-template.json",
-            "postgresql-persistent-template.json"
-        ]
+        ["postgresql-ephemeral-template.json", "postgresql-persistent-template.json"],
     )
     def test_psql_imagestream_template(self, template):
-        os_name = ''.join(i for i in OS if not i.isdigit())
+        os_name = "".join(i for i in VARS.OS if not i.isdigit())
         assert self.oc_api.deploy_image_stream_template(
             imagestream_file=f"imagestreams/postgresql-{os_name}.json",
             template_file=f"examples/{template}",
-            app_name=self.oc_api.pod_name_prefix
+            app_name=self.oc_api.pod_name_prefix,
         )
         assert self.oc_api.is_pod_running(pod_name_prefix=self.oc_api.pod_name_prefix)

--- a/test/test_ocp_psql_latest_imagestreams.py
+++ b/test/test_ocp_psql_latest_imagestreams.py
@@ -1,26 +1,13 @@
-import os
-import sys
-
-import pytest
-
-from pathlib import Path
-
 from container_ci_suite.imagestreams import ImageStreamChecker
-from container_ci_suite.utils import check_variables
 
-TEST_DIR = Path(os.path.abspath(os.path.dirname(__file__)))
-
-if not check_variables():
-    print("At least one variable from IMAGE_NAME, OS, VERSION is missing.")
-    sys.exit(1)
+from conftest import VARS
 
 
 class TestLatestImagestreams:
-
     def setup_method(self):
-        self.isc = ImageStreamChecker(working_dir=TEST_DIR.parent)
+        self.isc = ImageStreamChecker(working_dir=VARS.TEST_DIR.parent)
 
     def test_latest_imagestream(self):
         self.latest_version = self.isc.get_latest_version()
-        assert self.latest_version != ""
+        assert self.latest_version
         self.isc.check_imagestreams(self.latest_version)

--- a/test/test_ocp_psql_template.py
+++ b/test/test_ocp_psql_template.py
@@ -1,59 +1,44 @@
-import os
-import sys
-
 import pytest
 
 from container_ci_suite.openshift import OpenShiftAPI
-from container_ci_suite.utils import check_variables
 
-from constants import TAGS
-
-if not check_variables():
-    print("At least one variable from IMAGE_NAME, OS, VERSION is missing.")
-    sys.exit(1)
-
-
-VERSION = os.getenv("VERSION")
-IMAGE_NAME = os.getenv("IMAGE_NAME")
-OS = os.getenv("TARGET")
-
-TAG = TAGS.get(OS)
+from conftest import VARS
 
 
 class TestPostgreSQLDeployTemplate:
-
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="postgresql-testing", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(
+            pod_name_prefix="postgresql-testing",
+            version=VARS.VERSION,
+            shared_cluster=True,
+        )
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     @pytest.mark.parametrize(
         "template",
-        [
-            "postgresql-ephemeral-template.json",
-            "postgresql-persistent-template.json"
-        ]
+        ["postgresql-ephemeral-template.json", "postgresql-persistent-template.json"],
     )
     def test_psql_template_inside_cluster(self, template):
-        short_version = VERSION.replace(".", "")
+        short_version = VARS.VERSION.replace(".", "")
         assert self.oc_api.deploy_template_with_image(
-            image_name=IMAGE_NAME,
+            image_name=VARS.IMAGE_NAME,
             template=f"examples/{template}",
             name_in_template="postgresql",
             openshift_args=[
-                f"POSTGRESQL_VERSION={VERSION}",
+                f"POSTGRESQL_VERSION={VARS.VERSION}",
                 f"DATABASE_SERVICE_NAME={self.oc_api.pod_name_prefix}",
-                f"POSTGRESQL_USER=testu",
-                f"POSTGRESQL_PASSWORD=testp",
-                f"POSTGRESQL_DATABASE=testdb"
-            ]
+                "POSTGRESQL_USER=testu",
+                "POSTGRESQL_PASSWORD=testp",
+                "POSTGRESQL_DATABASE=testdb",
+            ],
         )
 
         assert self.oc_api.is_pod_running(pod_name_prefix=self.oc_api.pod_name_prefix)
         assert self.oc_api.check_command_internal(
-            image_name=f"registry.redhat.io/{OS}/postgresql-{short_version}",
+            image_name=f"registry.redhat.io/{VARS.OS}/postgresql-{short_version}",
             service_name=self.oc_api.pod_name_prefix,
             cmd="PGPASSWORD=testp pg_isready -t 15 -h <IP> -U testu -d testdb",
-            expected_output="accepting connections"
+            expected_output="accepting connections",
         )

--- a/test/test_ocp_shared_helm_psql_imagestreams.py
+++ b/test/test_ocp_shared_helm_psql_imagestreams.py
@@ -1,29 +1,24 @@
-import os
-import sys
-
 import pytest
 
-from pathlib import Path
 
 from container_ci_suite.helm import HelmChartsAPI
-from container_ci_suite.utils import check_variables
 
-if not check_variables():
-    print("At least one variable from IMAGE_NAME, OS, VERSION is missing.")
-    sys.exit(1)
-
-test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
+from conftest import VARS
 
 
 class TestHelmRHELPostgresqlImageStreams:
-
     def setup_method(self):
         package_name = "redhat-postgresql-imagestreams"
-        path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
+        self.hc_api = HelmChartsAPI(
+            path=VARS.TEST_DIR,
+            package_name=package_name,
+            tarball_dir=VARS.TEST_DIR,
+            shared_cluster=True,
+        )
         self.hc_api.clone_helm_chart_repo(
-            repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
-            subdir="charts/redhat"
+            repo_url="https://github.com/sclorg/helm-charts",
+            repo_name="helm-charts",
+            subdir="charts/redhat",
         )
 
     def teardown_method(self):
@@ -45,4 +40,7 @@ class TestHelmRHELPostgresqlImageStreams:
     def test_package_imagestream(self, version, registry, expected):
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected
+        assert (
+            self.hc_api.check_imagestreams(version=version, registry=registry)
+            == expected
+        )

--- a/test/test_ocp_shared_helm_psql_template.py
+++ b/test/test_ocp_shared_helm_psql_template.py
@@ -1,38 +1,21 @@
-import os
-import sys
-
-import pytest
-
-from pathlib import Path
-
 from container_ci_suite.helm import HelmChartsAPI
-from container_ci_suite.utils import check_variables
 
-from constants import TAGS
-
-if not check_variables():
-    print("At least one variable from IMAGE_NAME, OS, VERSION is missing.")
-    sys.exit(1)
-
-test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
-
-
-VERSION = os.getenv("VERSION")
-IMAGE_NAME = os.getenv("IMAGE_NAME")
-OS = os.getenv("TARGET")
-
-TAG = TAGS.get(OS)
+from conftest import VARS
 
 
 class TestHelmPostgresqlPersistent:
-
     def setup_method(self):
         package_name = "redhat-postgresql-persistent"
-        path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(
+            path=VARS.TEST_DIR,
+            package_name=package_name,
+            tarball_dir=VARS.TEST_DIR,
+            shared_cluster=True,
+        )
         self.hc_api.clone_helm_chart_repo(
-            repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
-            subdir="charts/redhat"
+            repo_url="https://github.com/sclorg/helm-charts",
+            repo_name="helm-charts",
+            subdir="charts/redhat",
         )
 
     def teardown_method(self):
@@ -46,9 +29,11 @@ class TestHelmPostgresqlPersistent:
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={
-                ".image.tag": f"{VERSION}{TAG}",
-                ".namespace": self.hc_api.namespace,
+                ".image.tag": f"{VARS.VERSION}{VARS.TAG}",
+                "namespace": self.hc_api.namespace,
             }
         )
-        assert self.hc_api.is_pod_running(pod_name_prefix="redhat-postgresql-persistent")
+        assert self.hc_api.is_pod_running(
+            pod_name_prefix="redhat-postgresql-persistent"
+        )
         assert self.hc_api.test_helm_chart(expected_str=["accepting connection"])


### PR DESCRIPTION
Update also OpenShift part.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4090021301"} -->

<!-- testing-farm = {"lock":"false","comment-id":"4090119888","data":[{"id":"73f9822c-9559-44a4-a271-549fe1f0824b","name":"RHEL10 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":721.989325,"created":"2026-03-19T13:13:56.410881","updated":"2026-03-19T13:13:56.410886","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/73f9822c-9559-44a4-a271-549fe1f0824b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/73f9822c-9559-44a4-a271-549fe1f0824b/pipeline.log\">pipeline</a>"]},{"id":"d87f2cf7-6111-4b6d-bd4f-a7cf2ecdbd51","name":"RHEL10 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":1034.86308,"created":"2026-03-19T13:13:54.321657","updated":"2026-03-19T13:13:54.321664","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d87f2cf7-6111-4b6d-bd4f-a7cf2ecdbd51\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d87f2cf7-6111-4b6d-bd4f-a7cf2ecdbd51/pipeline.log\">pipeline</a>"]},{"id":"ada305a0-9602-4844-aef0-7a66cc8280ac","name":"RHEL8 - PyTest - OpenShift 4 - 15","status":"complete","outcome":"passed","runTime":1046.108424,"created":"2026-03-19T13:13:54.459740","updated":"2026-03-19T13:13:54.459748","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ada305a0-9602-4844-aef0-7a66cc8280ac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ada305a0-9602-4844-aef0-7a66cc8280ac/pipeline.log\">pipeline</a>"]},{"id":"04b26e8a-b00f-4914-9504-018e16b67413","name":"RHEL9 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":969.760567,"created":"2026-03-19T13:13:57.245659","updated":"2026-03-19T13:13:57.245667","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/04b26e8a-b00f-4914-9504-018e16b67413\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/04b26e8a-b00f-4914-9504-018e16b67413/pipeline.log\">pipeline</a>"]},{"id":"6ee62638-e541-468e-b2ec-d62b191b5895","name":"RHEL8 - PyTest - OpenShift 4 - 12","status":"complete","outcome":"passed","runTime":1113.513305,"created":"2026-03-19T13:13:54.569785","updated":"2026-03-19T13:13:54.569791","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ee62638-e541-468e-b2ec-d62b191b5895\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ee62638-e541-468e-b2ec-d62b191b5895/pipeline.log\">pipeline</a>"]},{"id":"98f68018-32d2-494e-9494-0e3ad60a99ca","name":"RHEL8 - PyTest - OpenShift 4 - 13","status":"complete","outcome":"passed","runTime":1084.640556,"created":"2026-03-19T13:13:59.408481","updated":"2026-03-19T13:13:59.408488","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/98f68018-32d2-494e-9494-0e3ad60a99ca\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/98f68018-32d2-494e-9494-0e3ad60a99ca/pipeline.log\">pipeline</a>"]},{"id":"1d14c571-8700-4d37-a0a6-c48161f3c5ff","name":"RHEL8 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":1091.920347,"created":"2026-03-19T13:13:54.637730","updated":"2026-03-19T13:13:54.637737","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d14c571-8700-4d37-a0a6-c48161f3c5ff\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d14c571-8700-4d37-a0a6-c48161f3c5ff/pipeline.log\">pipeline</a>"]},{"id":"a9a1cee3-7607-4023-83c7-d001c491708a","name":"RHEL9 - PyTest - OpenShift 4 - 13","status":"complete","outcome":"passed","runTime":1291.331018,"created":"2026-03-19T13:13:57.180232","updated":"2026-03-19T13:13:57.180240","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a9a1cee3-7607-4023-83c7-d001c491708a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a9a1cee3-7607-4023-83c7-d001c491708a/pipeline.log\">pipeline</a>"]},{"id":"d880ebf3-5118-4691-954e-d39047266d40","name":"RHEL9 - PyTest - OpenShift 4 - 15","status":"complete","outcome":"passed","runTime":1338.642557,"created":"2026-03-19T13:13:55.035958","updated":"2026-03-19T13:13:55.035967","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d880ebf3-5118-4691-954e-d39047266d40\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d880ebf3-5118-4691-954e-d39047266d40/pipeline.log\">pipeline</a>"]},{"id":"3b47e0ab-a7e8-4895-b882-16bcb06eb5ff","name":"RHEL9 - PyTest - OpenShift 4 - 16","runTime":1329.053359,"created":"2026-03-19T13:13:55.098834","updated":"2026-03-19T13:13:55.098841","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3b47e0ab-a7e8-4895-b882-16bcb06eb5ff\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3b47e0ab-a7e8-4895-b882-16bcb06eb5ff/pipeline.log\">pipeline</a>"]}]} -->