### PR TITLE
OKD-380: Add missing namespace to image trigger annotations

### DIFF
--- a/examples/postgresql-ephemeral-template.json
+++ b/examples/postgresql-ephemeral-template.json
@@ -72,7 +72,7 @@
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {
           "template.alpha.openshift.io/wait-for-ready": "true",
-          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\",\"namespace\":\"${NAMESPACE}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {

--- a/examples/postgresql-persistent-template.json
+++ b/examples/postgresql-persistent-template.json
@@ -89,7 +89,7 @@
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {
           "template.alpha.openshift.io/wait-for-ready": "true",
-          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\",\"namespace\":\"${NAMESPACE}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {


### PR DESCRIPTION
## Problem

Deploying PostgreSQL from the OKD 4.22 Software Catalog fails with:

```
spec.containers[0].image: Invalid value: " ": must not have leading or trailing whitespace
```

Reported in https://github.com/okd-project/okd/issues/2337

## Root Cause

When templates were migrated from `DeploymentConfig` to `Deployment`, the `image.openshift.io/triggers` annotation dropped the `namespace` field from the `ImageStreamTag` reference. Without it, the image trigger controller defaults to the Deployment's own namespace instead of `openshift`, so it can't find the ImageStream and the container image is never resolved.

## Fix

Add `"namespace":"${NAMESPACE}"` to the trigger annotation's `from` object in both `postgresql-persistent` and `postgresql-ephemeral` templates. The `NAMESPACE` parameter already exists in both templates with a default value of `"openshift"`.

## Impact

These template files are the upstream source for `openshift/library` (via `make import`) and ultimately `openshift/cluster-samples-operator`. An immediate fix was applied directly to the operator in [openshift/cluster-samples-operator#701](https://github.com/openshift/cluster-samples-operator/pull/701). This upstream fix ensures the bug doesn't recur on the next sync.

<!-- issue-commentator = {"comment-id":"4775553886"} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL template configurations to include explicit namespace specifications for container image resolution in OpenShift environments, improving deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"4777591190","data":[{"id":"31744cc1-6e89-40b5-ba46-a571edcaf248","name":"RHEL10 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1038.464267,"created":"2026-06-23T08:53:15.321066","updated":"2026-06-23T08:53:15.321074","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/31744cc1-6e89-40b5-ba46-a571edcaf248\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/31744cc1-6e89-40b5-ba46-a571edcaf248/pipeline.log\">pipeline</a>"]},{"id":"06583e53-c680-445c-a696-355aca6e1ebb","name":"RHEL8 - PyTest - OpenShift 4 - 15","status":"complete","outcome":"passed","runTime":1732.94999,"created":"2026-06-23T10:32:12.923752","updated":"2026-06-23T10:32:12.923760","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/06583e53-c680-445c-a696-355aca6e1ebb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/06583e53-c680-445c-a696-355aca6e1ebb/pipeline.log\">pipeline</a>"]},{"id":"6cdc017d-4c98-4962-90a4-c3f5cf19d5b7","name":"RHEL8 - PyTest - OpenShift 4 - 13","status":"complete","outcome":"passed","runTime":1288.122184,"created":"2026-06-23T10:32:12.159677","updated":"2026-06-23T10:32:12.159685","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6cdc017d-4c98-4962-90a4-c3f5cf19d5b7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6cdc017d-4c98-4962-90a4-c3f5cf19d5b7/pipeline.log\">pipeline</a>"]},{"id":"182558d9-162e-4013-83f2-7e8068e65bdd","name":"RHEL9 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1705.546313,"created":"2026-06-23T09:13:11.531239","updated":"2026-06-23T09:13:11.531245","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/182558d9-162e-4013-83f2-7e8068e65bdd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/182558d9-162e-4013-83f2-7e8068e65bdd/pipeline.log\">pipeline</a>"]},{"id":"67eb0e3b-bb4f-403a-a381-c4c187bd41fa","name":"RHEL9 - PyTest - OpenShift 4 - 16","runTime":2097.17371,"created":"2026-06-23T10:32:11.139161","updated":"2026-06-23T10:32:11.139169","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/67eb0e3b-bb4f-403a-a381-c4c187bd41fa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/67eb0e3b-bb4f-403a-a381-c4c187bd41fa/pipeline.log\">pipeline</a>"]},{"id":"44275c8c-0d86-4233-9fb5-b62b34f0a092","name":"RHEL9 - PyTest - OpenShift 4 - 15","status":"complete","outcome":"passed","runTime":1963.770371,"created":"2026-06-23T10:32:14.082797","updated":"2026-06-23T10:32:14.082804","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/44275c8c-0d86-4233-9fb5-b62b34f0a092\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/44275c8c-0d86-4233-9fb5-b62b34f0a092/pipeline.log\">pipeline</a>"]},{"id":"45f36dbd-7ba1-4bbf-b770-50260be3a70f","name":"RHEL8 - PyTest - OpenShift 4 - 12","status":"complete","outcome":"passed","runTime":1383.455977,"created":"2026-06-23T10:32:13.515455","updated":"2026-06-23T10:32:13.515463","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/45f36dbd-7ba1-4bbf-b770-50260be3a70f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/45f36dbd-7ba1-4bbf-b770-50260be3a70f/pipeline.log\">pipeline</a>"]},{"id":"4940f9bb-29c0-4d8e-ae3d-edc8b206d694","name":"RHEL8 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":1407.348757,"created":"2026-06-23T10:32:13.101610","updated":"2026-06-23T10:32:13.101618","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4940f9bb-29c0-4d8e-ae3d-edc8b206d694\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4940f9bb-29c0-4d8e-ae3d-edc8b206d694/pipeline.log\">pipeline</a>"]},{"id":"3f882c28-1efa-4042-9e37-ee55a9d86276","name":"RHEL9 - PyTest - OpenShift 4 - 13","status":"complete","outcome":"passed","runTime":1842.182949,"created":"2026-06-23T10:32:11.480827","updated":"2026-06-23T10:32:11.480835","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3f882c28-1efa-4042-9e37-ee55a9d86276\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3f882c28-1efa-4042-9e37-ee55a9d86276/pipeline.log\">pipeline</a>"]},{"id":"1f0a121d-3b7a-4435-b915-763523e74c4d","name":"RHEL10 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":1895.79511,"created":"2026-06-23T10:32:13.988832","updated":"2026-06-23T10:32:13.988841","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1f0a121d-3b7a-4435-b915-763523e74c4d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1f0a121d-3b7a-4435-b915-763523e74c4d/pipeline.log\">pipeline</a>"]}]} -->