### PR TITLE
Set PREV_VERSION to 13 on el10 PG 16 images

### DIFF
--- a/16/Dockerfile.c10s
+++ b/16/Dockerfile.c10s
@@ -11,7 +11,7 @@ FROM quay.io/sclorg/s2i-core-c10s:c10s
 #                           PostgreSQL administrative account
 
 ENV POSTGRESQL_VERSION=16 \
-    POSTGRESQL_PREV_VERSION=15 \
+    POSTGRESQL_PREV_VERSION=13 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres \
     APP_DATA=/opt/app-root

--- a/16/Dockerfile.rhel10
+++ b/16/Dockerfile.rhel10
@@ -11,7 +11,7 @@ FROM ubi10/s2i-core
 #                           PostgreSQL administrative account
 
 ENV POSTGRESQL_VERSION=16 \
-    POSTGRESQL_PREV_VERSION=15 \
+    POSTGRESQL_PREV_VERSION=13 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres \
     APP_DATA=/opt/app-root


### PR DESCRIPTION
Fixes https://github.com/sclorg/postgresql-container/issues/661 The binaries inside the container for the previous version are from version 13, let's set the default ENV variables to match the packages.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PostgreSQL 16 container configuration to use PostgreSQL 13 as the referenced previous major version in supported image builds.
  * Applied the same environment setting update across both Linux image variants, with no other visible runtime or port changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- issue-commentator = {"comment-id":"4855772498"} -->